### PR TITLE
readOnly Update

### DIFF
--- a/projects/schema-form/src/lib/defaultwidgets/checkbox/checkbox.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/checkbox/checkbox.widget.ts
@@ -10,7 +10,7 @@ import { ControlWidget } from '../../widget';
     </label>
 	<div *ngIf="schema.type!='array'" class="checkbox">
 		<label class="horizontal control-label">
-			<input [formControl]="control" [attr.name]="name" [indeterminate]="control.value !== false && control.value !== true ? true :null" type="checkbox" [attr.disabled]="schema.readOnly">
+			<input [formControl]="control" [attr.name]="name" [indeterminate]="control.value !== false && control.value !== true ? true :null" type="checkbox" [disabled]="schema.readOnly">
 			<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
 			{{schema.description}}
 		</label>

--- a/projects/schema-form/src/lib/defaultwidgets/radio/radio.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/radio/radio.widget.ts
@@ -9,7 +9,7 @@ import { ControlWidget } from '../../widget';
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
 	<div *ngFor="let option of schema.oneOf" class="radio">
 		<label class="horizontal control-label">
-			<input [formControl]="control" [attr.name]="name" value="{{option.enum[0]}}" type="radio"  [attr.disabled]="schema.readOnly">
+			<input [formControl]="control" [attr.name]="name" value="{{option.enum[0]}}" type="radio"  [disabled]="schema.readOnly">
 			{{option.description}}
 		</label>
 	</div>

--- a/projects/schema-form/src/lib/defaultwidgets/range/range.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/range/range.widget.ts
@@ -10,7 +10,7 @@ import { ControlWidget } from '../../widget';
 	</label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>	
 	<input [name]="name" class="text-widget range-widget" [attr.id]="id"
-	[formControl]="control" [attr.type]="'range'" [attr.min]="schema.minimum" [attr.max]="schema.maximum" [attr.disabled]="schema.readOnly?true:null" >
+	[formControl]="control" [attr.type]="'range'" [attr.min]="schema.minimum" [attr.max]="schema.maximum" [disabled]="schema.readOnly?true:null" >
 	<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden">
 </div>`
 })

--- a/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
@@ -13,11 +13,11 @@ import { ControlWidget } from '../../widget';
 		{{schema.description}}
 	</span>
 
-	<select *ngIf="schema.type!='array'" [formControl]="control" [attr.name]="name" [attr.disabled]="schema.readOnly" class="form-control">
+	<select *ngIf="schema.type!='array'" [formControl]="control" [attr.name]="name" [disabled]="schema.readOnly" class="form-control">
 		<option *ngFor="let option of schema.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
 	</select>
 
-	<select *ngIf="schema.type==='array'" multiple [formControl]="control" [attr.name]="name" [attr.disabled]="schema.readOnly" class="form-control">
+	<select *ngIf="schema.type==='array'" multiple [formControl]="control" [attr.name]="name" [disabled]="schema.readOnly" class="form-control">
 		<option *ngFor="let option of schema.items.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
 	</select>
 

--- a/projects/schema-form/src/lib/defaultwidgets/textarea/textarea.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/textarea/textarea.widget.ts
@@ -9,7 +9,7 @@ import { ControlWidget } from '../../widget';
 		{{ schema.title }}
 	</label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
-	<textarea [attr.readonly]="schema.readOnly" [name]="name"
+	<textarea [readonly]="schema.readOnly" [name]="name"
 		class="text-widget textarea-widget form-control"
 		[attr.placeholder]="schema.placeholder"
 		[attr.maxLength]="schema.maxLength || null"


### PR DESCRIPTION
I conditionally set and unset the readOnly property (true/false) and have been running into some issues where the read only property doesn't seem to be unsetting. 

I think it might be because `[attr.readonly]="schema.readOnly"` will set the readonly property when schema.readOnly = false. Here's a [stackOverflow post](https://stackoverflow.com/questions/45226354/conditionally-make-input-field-readonly-in-angular-2-or-4-advice-best-which-w) about it as well. It should be: [readonly]="schema.readOnly" unless there is a specific reason `[attr.readonly]` is needed?

I guess the alternative is what I've seen used in the default string widget: 

`[attr.readonly]="(schema.widget.id!=='color') && schema.readOnly?true:null"`
Setting the value to null if it doesn't exist, which would not set the readonly property. Either way, think it needs to be updated for textarea and some of the other widgets.