### PR TITLE
exented visibleIf condition with `oneOf` and `allOf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ export class AppComponent {
   }
 }
 ```
-Assigning an empty Object to 'visibleIf' is interpreted as _visibleIf_ nothing, thereby the widget is hidden.
+Assigning an empty Object to 'visibleIf' is interpreted as _visibleIf_ nothing, thereby the widget is hidden and not present in model.
 ```js
 mySchema = {
     "properties": {
@@ -574,6 +574,29 @@ mySchema = {
     }
   }
 ```
+
+`visibleIf` may also declare conditional binding by using `oneOf` or `allOf` properties.
+Where `oneOf` is handled as `OR` and `allOf` is handled as `AND`.
+```
+  "visibleIf": {
+        "allOf": [
+          {
+            "forename": [
+              "$ANY$"
+            ]
+          },
+          {
+            "name": [
+              "$ANY$"
+            ]
+          }
+        ]
+      }
+```
+The `oneOf` a is prioritized before the `allOf` and both are prioritized before the 
+property binding.
+ 
+_`oneOf` and `allOf` oneOf and allOf are reserved keywords and not suitable as property names_
 
 #### Hidden fields
 When a field has been made invisible by the condition `visibleIf`

--- a/src/app/json-schema-example/binding_sample_schema.json
+++ b/src/app/json-schema-example/binding_sample_schema.json
@@ -32,6 +32,24 @@
           }
         }
       }
+    },
+    "test": {
+      "type": "string",
+      "title": "Testparam",
+      "visibleIf": {
+        "allOf": [
+          {
+            "forename": [
+              "$ANY$"
+            ]
+          },
+          {
+            "name": [
+              "$ANY$"
+            ]
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Request for extending capabilities of `visibleIf` with simple `OR` and `AND` by using `oneOf` and `allOf`.

e.g. 
```
  "visibleIf": {
        "allOf": [
          {
            "forename": [
              "$ANY$"
            ]
          },
          {
            "name": [
              "$ANY$"
            ]
          }
        ]
      }
```
and 
```
  "visibleIf": {
        "oneOf": [
          {
            "forename": [
              "$ANY$"
            ]
          },
          {
            "name": [
              "$ANY$"
            ]
          }
        ]
      }
```

Backward compatible: You still can use the already known direct binding with the properties of `visibleIf` ...

... but maybe with should go further in future and remove the direct property binding in `visibleIf` completely and replace it with usual JSON object declaration.

This would bring the benefit of having properties like `maximum` and `minimum` and so on...
