### PR TITLE
add support for visibility bindings on array type widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,40 @@ property binding.
  
 _`oneOf` and `allOf` oneOf and allOf are reserved keywords and not suitable as property names_
 
+**Arrays**
+
+To address array items or not yet existing properties the `visibleIf` 
+condition path may contain wildcard `*`.
+
+e.g 
+```
+  "visibleIf": {
+        "oneOf": [
+          {
+            "/person/*/age": [
+              "18"
+            ]
+          }
+        ]
+      }
+```
+
+To address a specific item the `visibleIf` 
+condition path should contain the index position.
+
+e.g 
+```
+  "visibleIf": {
+        "oneOf": [
+          {
+            "/person/1/age": [
+              "18"
+            ]
+          }
+        ]
+      }
+```
+
 #### Hidden fields
 When a field has been made invisible by the condition `visibleIf`
 then the property of the invisible field will be missing in the result model.

--- a/projects/schema-form/src/lib/form.component.ts
+++ b/projects/schema-form/src/lib/form.component.ts
@@ -22,9 +22,10 @@ import {BindingRegistry} from './model/bindingregistry';
 import {SchemaValidatorFactory} from './schemavalidatorfactory';
 import {WidgetFactory} from './widgetfactory';
 import {TerminatorService} from './terminator.service';
+import {PropertyBindingRegistry} from './property-binding-registry';
 
-export function useFactory(schemaValidatorFactory, validatorRegistry) {
-  return new FormPropertyFactory(schemaValidatorFactory, validatorRegistry);
+export function useFactory(schemaValidatorFactory, validatorRegistry, propertyBindingRegistry) {
+  return new FormPropertyFactory(schemaValidatorFactory, validatorRegistry, propertyBindingRegistry);
 }
 
 @Component({
@@ -37,13 +38,14 @@ export function useFactory(schemaValidatorFactory, validatorRegistry) {
   providers: [
     ActionRegistry,
     ValidatorRegistry,
+    PropertyBindingRegistry,
     BindingRegistry,
     SchemaPreprocessor,
     WidgetFactory,
     {
       provide: FormPropertyFactory,
       useFactory: useFactory,
-      deps: [SchemaValidatorFactory, ValidatorRegistry]
+      deps: [SchemaValidatorFactory, ValidatorRegistry, PropertyBindingRegistry]
     },
     TerminatorService,
     {

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -1,8 +1,9 @@
-import {Observable, BehaviorSubject, combineLatest} from 'rxjs';
-import { map, distinctUntilChanged } from 'rxjs/operators';
+import {BehaviorSubject, combineLatest} from 'rxjs';
+import {distinctUntilChanged, map} from 'rxjs/operators';
 
 import {SchemaValidatorFactory} from '../schemavalidatorfactory';
 import {ValidatorRegistry} from './validatorregistry';
+import {PropertyBindingRegistry} from '../property-binding-registry';
 
 export abstract class FormProperty {
   public schemaValidator: Function;
@@ -16,6 +17,8 @@ export abstract class FormProperty {
   private _root: PropertyGroup;
   private _parent: PropertyGroup;
   private _path: string;
+  _propertyBindingRegistry: PropertyBindingRegistry;
+  _canonicalPath: string;
 
   constructor(schemaValidatorFactory: SchemaValidatorFactory,
               private validatorRegistry: ValidatorRegistry,
@@ -188,7 +191,7 @@ export abstract class FormProperty {
      *     }]
      *     </pre>
      */
-    const visibleIfProperty = this.schema.visibleIf
+    const visibleIfProperty = this.schema.visibleIf;
     const visibleIfOf = (visibleIfProperty || {}).oneOf || (visibleIfProperty || {}).allOf;
     if (visibleIfOf) {
       for (const visibleIf of visibleIfOf) {
@@ -198,45 +201,52 @@ export abstract class FormProperty {
           const propertiesBinding = [];
           for (const dependencyPath in visibleIf) {
             if (visibleIf.hasOwnProperty(dependencyPath)) {
-              const property = this.searchProperty(dependencyPath);
-              if (property) {
-                let valueCheck
-                if (this.schema.visibleIf.oneOf) {
-                  valueCheck = property.valueChanges.pipe(map(
-                    value => {
-                      if (visibleIf[dependencyPath].indexOf('$ANY$') !== -1) {
-                        return value.length > 0;
-                      } else {
-                        return visibleIf[dependencyPath].indexOf(value) !== -1;
-                      }
-                    }
-                  ));
-                } else if (this.schema.visibleIf.allOf) {
-                  const _chk = (value) => {
-                    for (const item of this.schema.visibleIf.allOf) {
-                      for (const depPath of Object.keys(item)) {
-                        const prop = this.searchProperty(depPath);
-                        const propVal = prop._value;
-                        let valid = false;
-                        if (item[depPath].indexOf('$ANY$') !== -1) {
-                          valid = propVal.length > 0;
-                        } else {
-                          valid = item[depPath].indexOf(propVal) !== -1;
+              const properties = this.findProperties(this, dependencyPath);
+              if ((properties || []).length) {
+                for (const property of properties) {
+                  if (property) {
+                    let valueCheck;
+                    if (this.schema.visibleIf.oneOf) {
+                      valueCheck = property.valueChanges.pipe(map(
+                        value => {
+                          if (visibleIf[dependencyPath].indexOf('$ANY$') !== -1) {
+                            return value.length > 0;
+                          } else {
+                            return visibleIf[dependencyPath].indexOf(value) !== -1;
+                          }
                         }
-                        if (!valid) {
-                          return false;
+                      ));
+                    } else if (this.schema.visibleIf.allOf) {
+                      const _chk = (value) => {
+                        for (const item of this.schema.visibleIf.allOf) {
+                          for (const depPath of Object.keys(item)) {
+                            const prop = this.searchProperty(depPath);
+                            const propVal = prop._value;
+                            let valid = false;
+                            if (item[depPath].indexOf('$ANY$') !== -1) {
+                              valid = propVal.length > 0;
+                            } else {
+                              valid = item[depPath].indexOf(propVal) !== -1;
+                            }
+                            if (!valid) {
+                              return false;
+                            }
+                          }
                         }
-                      }
+                        return true;
+                      };
+                      valueCheck = property.valueChanges.pipe(map(_chk));
                     }
-                    return true;
-                  };
-                  valueCheck = property.valueChanges.pipe(map(_chk));
+                    const visibilityCheck = property._visibilityChanges;
+                    const and = combineLatest([valueCheck, visibilityCheck], (v1, v2) => v1 && v2);
+                    propertiesBinding.push(and);
+                  }
                 }
-                const visibilityCheck = property._visibilityChanges;
-                const and = combineLatest([valueCheck, visibilityCheck], (v1, v2) => v1 && v2);
-                propertiesBinding.push(and);
               } else {
                 console.warn('Can\'t find property ' + dependencyPath + ' for visibility check of ' + this.path);
+                this.registerMissingVisibilityBinding(dependencyPath, this);
+                // not visible if not existent
+                this.setVisible(false);
               }
             }
           }
@@ -254,32 +264,38 @@ export abstract class FormProperty {
 
   // A field is visible if AT LEAST ONE of the properties it depends on is visible AND has a value in the list
   public _bindVisibility() {
-    if(this.__bindVisibility())
-      return
+    if (this.__bindVisibility())
+      return;
     let visibleIf = this.schema.visibleIf;
     if (typeof visibleIf === 'object' && Object.keys(visibleIf).length === 0) {
       this.setVisible(false);
-    }
-    else if (visibleIf !== undefined) {
+    } else if (visibleIf !== undefined) {
       let propertiesBinding = [];
       for (let dependencyPath in visibleIf) {
         if (visibleIf.hasOwnProperty(dependencyPath)) {
-          let property = this.searchProperty(dependencyPath);
-          if (property) {
-            const valueCheck = property.valueChanges.pipe(map(
-              value => {
-                if (visibleIf[dependencyPath].indexOf('$ANY$') !== -1) {
-                  return value.length > 0;
-                } else {
-                  return visibleIf[dependencyPath].indexOf(value) !== -1;
-                }
+          const properties = this.findProperties(this, dependencyPath);
+          if ((properties || []).length) {
+            for (const property of properties) {
+              if (property) {
+                const valueCheck = property.valueChanges.pipe(map(
+                  value => {
+                    if (visibleIf[dependencyPath].indexOf('$ANY$') !== -1) {
+                      return value.length > 0;
+                    } else {
+                      return visibleIf[dependencyPath].indexOf(value) !== -1;
+                    }
+                  }
+                ));
+                const visibilityCheck = property._visibilityChanges;
+                const and = combineLatest([valueCheck, visibilityCheck], (v1, v2) => v1 && v2);
+                propertiesBinding.push(and);
               }
-            ));
-            const visibilityCheck = property._visibilityChanges;
-            const and = combineLatest([valueCheck, visibilityCheck], (v1, v2) => v1 && v2);
-            propertiesBinding.push(and);
+            }
           } else {
             console.warn('Can\'t find property ' + dependencyPath + ' for visibility check of ' + this.path);
+            this.registerMissingVisibilityBinding(dependencyPath, this);
+            // not visible if not existent
+            this.setVisible(false);
           }
         }
       }
@@ -291,11 +307,184 @@ export abstract class FormProperty {
       });
     }
   }
+
+  private registerMissingVisibilityBinding(dependencyPath: string, formProperty: FormProperty) {
+    formProperty._propertyBindingRegistry.getPropertyBindingsVisibility().add(dependencyPath, formProperty.path);
+  }
+
+
+  /**
+   * Finds all <code>formProperties</code> from a path with wildcards.<br/>
+   * e.g: <code>/garage/cars/&#42;/tires/&#42;/name</code><br/>
+   * @param target
+   * @param propertyPath
+   */
+  findProperties(target: FormProperty, propertyPath: string): FormProperty[] {
+    const props: FormProperty[] = [];
+    const paths = this.findPropertyPaths(target, propertyPath);
+    for (const path of paths) {
+      const p: FormProperty = target.searchProperty(path);
+      if (p) {
+        props.push(p);
+      }
+    }
+    return props;
+  }
+
+  /**
+   * Creates canonical paths from a path with wildcards.
+   * e.g:<br/>
+   * From:<br/>
+   * <code>/garage/cars/&#42;/tires/&#42;/name</code><br/>
+   * it creates:<br/>
+   * <code>/garage/cars/0/tires/0/name</code><br/>
+   * <code>/garage/cars/0/tires/1/name</code><br/>
+   * <code>/garage/cars/0/tires/2/name</code><br/>
+   * <code>/garage/cars/0/tires/3/name</code><br/>
+   * <code>/garage/cars/1/tires/0/name</code><br/>
+   * <code>/garage/cars/2/tires/1/name</code><br/>
+   * <code>/garage/cars/3/tires/2/name</code><br/>
+   * <code>/garage/cars/3/tires/3/name</code><br/>
+   * <code>/garage/cars/&#42;/tires/&#42;/name</code><br/>
+   * <code>/garage/cars/&#42;/tires/2/name</code><br/>
+   * <code>/garage/cars/&#42;/tires/3/name</code><br/>
+   * <br/>etc...
+   * @param target
+   * @param path
+   * @param parentPath
+   */
+  findPropertyPaths(target: FormProperty, path: string, parentPath?: string): string[] {
+    const ix = path.indexOf('*');
+    if (-1 !== ix) {
+      const prePath = ix > -1 ? path.substring(0, ix - 1) : path;
+      const subPath = ix > -1 ? path.substring(ix + 1) : path;
+      const prop: FormProperty = target.searchProperty(prePath);
+      let pathFound = [];
+      if (prop instanceof PropertyGroup) {
+        const arrProp = prop.properties as FormProperty[];
+        for (let i = 0; i < arrProp.length; i++) {
+          const curreItemPath = (parentPath || '') + prePath + (prePath.endsWith('/') ? '' : '/') + i + subPath;
+          const curreItemPrePath = (parentPath || '') + prePath + i;
+          if (-1 === curreItemPath.indexOf('*')) {
+            pathFound.push(curreItemPath);
+          }
+          const childrenPathFound = this.findPropertyPaths(arrProp[i], subPath, curreItemPrePath);
+          pathFound = pathFound.concat(childrenPathFound);
+        }
+      }
+      return pathFound;
+    }
+    return [path];
+  }
 }
 
 export abstract class PropertyGroup extends FormProperty {
 
-  properties: FormProperty[] | { [key: string]: FormProperty } = null;
+  _properties: FormProperty[] | { [key: string]: FormProperty } = null;
+
+  get properties() {
+    return this._properties;
+  }
+
+  set properties(properties: FormProperty[] | { [key: string]: FormProperty }) {
+    /**
+     * Override the setter to add an observer for new added items to it.<br/>
+     * Adding a new property will check for visibility to be updated<br/>
+     * if any other field has a binding reference to it.<br/>
+     */
+    const _prop = new Proxy(properties, {
+      set(target: FormProperty[] | { [p: string]: FormProperty }, p: PropertyKey, value: any, receiver: any): boolean {
+
+        const property = value as FormProperty;
+        /**
+         * 1) Make sure a canonical path is set
+         */
+        if (Array.isArray(target) && value instanceof FormProperty) {
+          /**
+           * Create a canonical path replacing the last '*' with the elements position in array
+           * @param propertyPath
+           * @param indexOfChild
+           */
+          const getCanonicalPath = (propertyPath: string, indexOfChild: number) => {
+            let pos;
+            if (propertyPath && -1 !== (pos = propertyPath.lastIndexOf('*'))) {
+              return propertyPath.substring(0, pos) + indexOfChild.toString() + propertyPath.substring(pos + 1);
+            }
+          };
+          if (property) {
+            property._canonicalPath = getCanonicalPath(property._canonicalPath, p as number);
+          }
+        }
+
+        const propertyGroup = property as PropertyGroup;
+        const children = (Array.isArray(propertyGroup.properties) ?
+          propertyGroup.properties :
+          Object.values(propertyGroup.properties || {})) as FormProperty[];
+        if ((property.path || '').endsWith('/*')) {
+          /**
+           * If it is an array, then all children canonical paths must be computed now.
+           * The children don't have the parent's path segment set yet,
+           * because they are created before the parent gets attached to its parent.
+           */
+          for (const child of children) {
+            child._canonicalPath = property._canonicalPath + child._canonicalPath.substring(property.path.length);
+          }
+        }
+
+
+        /**
+         * 2) Add the new property before rebinding, so it can be found by <code>_bindVisibility</code>
+         */
+        const result = target[p as string] = value;
+
+        /**
+         * 3) Re-bind the visibility bindings referencing to this canonical paths
+         */
+        const rebindAll = [property].concat(children);
+        const findPropertiesToRebind = (formProperty: FormProperty) => {
+          const propertyBindings = formProperty._propertyBindingRegistry.getPropertyBindingsVisibility();
+          let rebind: string[] = [];
+          if (formProperty._canonicalPath) {
+            rebind = rebind.concat(rebind.concat(propertyBindings.findByDependencyPath(formProperty._canonicalPath) || []));
+            if (formProperty._canonicalPath.startsWith('/')) {
+              rebind = rebind.concat(rebind.concat(propertyBindings.findByDependencyPath(formProperty._canonicalPath.substring(1)) || []));
+            }
+          }
+          rebind = rebind.concat(propertyBindings.findByDependencyPath(formProperty.path) || []);
+          if (formProperty.path.startsWith('/')) {
+            rebind = rebind.concat(rebind.concat(propertyBindings.findByDependencyPath(formProperty.path.substring(1)) || []));
+          }
+          const uniqueValues = {};
+          for (const item of rebind) {
+            uniqueValues[item] = item;
+          }
+          return Object.keys(uniqueValues);
+        };
+        for (const _property of rebindAll) {
+          if (_property instanceof FormProperty) {
+            try {
+              const rebindPaths = findPropertiesToRebind(_property);
+              for (const rebindPropPath of rebindPaths) {
+                const rebindProp = _property.searchProperty(rebindPropPath);
+                rebindProp._bindVisibility();
+              }
+            } catch (e) {
+              console.error('Rebinding visibility error at path:', _property.path, 'property:', _property, e);
+            }
+          }
+        }
+
+        return result;
+      },
+      get(target: FormProperty[] | { [p: string]: FormProperty }, p: PropertyKey, receiver: any): any {
+        return target[p as string];
+      },
+      deleteProperty(target: FormProperty[] | { [p: string]: FormProperty }, p: PropertyKey): boolean {
+        return delete target[p as string];
+      }
+    });
+    this._properties = _prop;
+  }
 
   getProperty(path: string) {
     let subPathIdx = path.indexOf('/');

--- a/projects/schema-form/src/lib/model/objectproperty.spec.ts
+++ b/projects/schema-form/src/lib/model/objectproperty.spec.ts
@@ -6,12 +6,14 @@ import {
 } from '../schemavalidatorfactory';
 
 import { ValidatorRegistry } from './validatorregistry';
+import {PropertyBindingRegistry} from '../property-binding-registry';
 
 describe('ObjectProperty', () => {
 
   let A_VALIDATOR_REGISTRY = new ValidatorRegistry();
   let A_SCHEMA_VALIDATOR_FACTORY = new ZSchemaValidatorFactory();
-  let A_FORM_PROPERTY_FACTORY = new FormPropertyFactory(A_SCHEMA_VALIDATOR_FACTORY, A_VALIDATOR_REGISTRY);
+  let A_PROPERTY_BINDING_REGISTRY=new PropertyBindingRegistry();
+  let A_FORM_PROPERTY_FACTORY = new FormPropertyFactory(A_SCHEMA_VALIDATOR_FACTORY, A_VALIDATOR_REGISTRY, A_PROPERTY_BINDING_REGISTRY);
 
 
   let THE_OBJECT_SCHEMA = {

--- a/projects/schema-form/src/lib/property-binding-registry.ts
+++ b/projects/schema-form/src/lib/property-binding-registry.ts
@@ -1,0 +1,187 @@
+/**
+ * General purpose propery binding registry
+ */
+export class PropertyBindingRegistry {
+
+  private bindings: { [key: string]: PropertyBindings } = {};
+
+  getPropertyBindings(type: PropertyBindingTypes): PropertyBindings {
+    this.bindings[type] = this.bindings[type] || new PropertyBindings();
+    return this.bindings[type];
+  }
+
+  getPropertyBindingsVisibility() {
+    return this.getPropertyBindings(PropertyBindingTypes.visibility);
+  }
+}
+
+/**
+ * Defines the types of supported property bindings.<br/>
+ * For now only <code>visibility</code> is supported.<br/>
+ */
+export enum PropertyBindingTypes {
+  visibility
+}
+
+/**
+ * Storage that holds all bindings that are property paths related.<br/>
+ */
+export class PropertyBindings {
+  sourcesIndex: SimplePropertyIndexer = new SimplePropertyIndexer();
+  dependenciesIndex: SimplePropertyIndexer = new SimplePropertyIndexer();
+
+  add(dependencyPath: string, sourcePropertyPath: string) {
+    this.sourcesIndex.store(sourcePropertyPath, dependencyPath);
+    this.dependenciesIndex.store(dependencyPath, sourcePropertyPath);
+  }
+
+  findByDependencyPath(dependencyPath: string): string[] {
+    const result = this.dependenciesIndex.find(dependencyPath);
+    result.results = result.results || [];
+    let values = [];
+    for (const res of result.results) {
+      values = values.concat(Object.keys(res.value));
+    }
+    console.log('::::findByDependencyPath', dependencyPath, result);
+    return result.found ? values : [];
+  }
+
+  getBySourcePropertyPath(sourcePropertyPath: string): string[] {
+    const result = this.sourcesIndex.find(sourcePropertyPath);
+    result.results = result.results || [];
+    let values = [];
+    for (const res of result.results) {
+      values = values.concat(Object.keys(res.value));
+    }
+    return result.found ? values : [];
+  }
+
+  createPathIndex(path: string): string[] {
+    return path.split('/');
+  }
+}
+
+/**
+ * Simple indexer to store property paths
+ */
+export class SimplePropertyIndexer {
+
+  static MARKER = '$____value';
+  index: object = {};
+  findOnlyWithValue = true;
+
+  private _createPathIndex(path: string) {
+    return path
+      .replace(new RegExp('//', 'g'), '/')
+      .replace(new RegExp('^/', 'g'), '')
+      .split('/').filter(item => item);
+  }
+
+  store(propertyPath: string, value?: any) {
+    this._storeIndex(this._createPathIndex(propertyPath), value);
+  }
+
+  private _storeIndex(pathIndex: string[], value?: string) {
+    let indexPos = this.index;
+    for (const key of pathIndex) {
+      indexPos[key] = indexPos[key] || {};
+      indexPos = indexPos[key];
+    }
+    if (indexPos && value) {
+      indexPos[SimplePropertyIndexer.MARKER] = indexPos[SimplePropertyIndexer.MARKER] || {};
+      indexPos[SimplePropertyIndexer.MARKER][value] = value;
+    }
+    console.log(':::INDEX:::', this.index);
+  }
+
+  /**
+   * Find path in index.<br/>
+   * Will find path like:<br/>
+   * <ul>
+   *     <li>/property/0/prop</li>
+   *     <li>/property/0/prop/2/test</li>
+   *     <li>/property/0/prop/&#42;/test</li>
+   *     <li>/property/&#42;/prop/1/test</li>
+   *     <li>/property/&#42;/prop/&#42;/test</li>
+   *     <li>/property/1/prop/&#42;/test</li>
+   *  </ul>
+   * @param path
+   */
+  find(path: string): IndexerResult {
+    return this._findInIndex(this._createPathIndex(path));
+  }
+
+  _findInIndex(path: string[]): IndexerResult {
+    const ixRes: IndexerResult = {target: path, found: false, results: []};
+    this.__findIndex(ixRes, path, this.index, []);
+    return ixRes;
+  }
+
+  __findIndex(indexerResults: IndexerResult, path: string[], index: object, parent?: string[]) {
+
+    const p = parent || [];
+    const segment = path[0];
+    const wild = ('*' === segment) ? Object.keys(index) : [];
+    const _keys = ((Array.isArray(segment) ? segment : [segment]) as string[]).concat(wild);
+    const keys = _keys.filter((item, pos) => '*' !== item && _keys.indexOf(item) === pos); // remove duplicates
+
+    if (index['*']) {
+      keys.push('*');
+    }
+
+    let paths = [];
+    for (const key of keys) {
+      const restPath = path.slice(1);
+      const restIndex = index[key];
+      const restParent = p.concat(key);
+
+      if (path.length === 1) {// collect only the full paths
+        if (!this.findOnlyWithValue || (restIndex && restIndex[SimplePropertyIndexer.MARKER])) {
+          indexerResults.results = indexerResults.results || [];
+          indexerResults.results.push({
+            path: restParent,
+            value: restIndex[SimplePropertyIndexer.MARKER]
+          });
+          paths.push(restParent);
+          indexerResults.found = indexerResults.results.length > 0;
+        }
+      }
+
+      if (!restPath || !restPath.length || !restIndex) {
+        break;
+      }
+      const restPaths = this.__findIndex(indexerResults, restPath, restIndex, restParent);
+
+      paths = paths.concat(restPaths);
+    }
+    return paths;
+  }
+
+}
+
+export interface IndexerResult {
+  /**
+   * The path originally searched for
+   */
+  target: string[];
+  /**
+   * Flag for the status of found or not found.<br/>
+   * Usually <code>results</code> will be empty if no matches found.
+   */
+  found: boolean;
+  /**
+   * The result path and values from the index search.<br/>
+   * Usually <code>results</code> will be empty if no matches found.
+   */
+  results: {
+    /**
+     * The path that matched the <code>target</code>
+     * separated in segments
+     */
+    path: string[],
+    /**
+     * The value stored at the <code>path</code>
+     */
+    value: any
+  }[];
+}

--- a/projects/schema-form/src/lib/property-binding-registry.ts
+++ b/projects/schema-form/src/lib/property-binding-registry.ts
@@ -42,7 +42,6 @@ export class PropertyBindings {
     for (const res of result.results) {
       values = values.concat(Object.keys(res.value));
     }
-    console.log('::::findByDependencyPath', dependencyPath, result);
     return result.found ? values : [];
   }
 
@@ -91,7 +90,6 @@ export class SimplePropertyIndexer {
       indexPos[SimplePropertyIndexer.MARKER] = indexPos[SimplePropertyIndexer.MARKER] || {};
       indexPos[SimplePropertyIndexer.MARKER][value] = value;
     }
-    console.log(':::INDEX:::', this.index);
   }
 
   /**

--- a/src/app/json-schema-example/json-schema-example.component.ts
+++ b/src/app/json-schema-example/json-schema-example.component.ts
@@ -13,6 +13,7 @@ import sampleModel from './samplemodel.json';
 import binding_sample_schema from './binding_sample_schema.json';
 import binding_sample_model from './binding_sample_model.json';
 import binding_sample_bindings from './binding_sample_bindings';
+import visibility_binding_example from './visibility-binding-example-schema.json';
 
 import {AppService, AppData} from '../app.service';
 
@@ -33,9 +34,10 @@ export class JsonSchemaExampleComponent implements OnInit, OnDestroy {
   private subs: Subscription;
 
   samples = [
-    {label: 'Sample 1 - General', event: this.changeSchemaFirst, selected: true},
+    {label: 'Sample 1 - General', event: this.changeSchemaFirst, selected: false},
     {label: 'Sample 2 - Custom bindings', event: this.changeSchemaWithBindings, selected: false},
-    {label: 'Sample 3 - Otherschema', event: this.changeSchemaOtherschema, selected: false}
+    {label: 'Sample 3 - Otherschema', event: this.changeSchemaOtherschema, selected: false},
+    {label: 'Sample 4 - Visibility binding', event: this.changeSchemaVisibilityBinding, selected: true},
   ];
 
   constructor(
@@ -77,7 +79,6 @@ export class JsonSchemaExampleComponent implements OnInit, OnDestroy {
   }
 
   changeSchema(event) {
-    console.log(event);
     for (const sample of this.samples) {
       if (sample.label === event) {
         sample.event.bind(this)();
@@ -195,6 +196,14 @@ export class JsonSchemaExampleComponent implements OnInit, OnDestroy {
     this.schema = binding_sample_schema;
     this.model = binding_sample_model;
     this.fieldBindings = binding_sample_bindings;
+    this.fieldValidators = {};
+    this.actions = {};
+  }
+
+  changeSchemaVisibilityBinding() {
+    this.schema = visibility_binding_example;
+    this.model = {};
+    this.fieldBindings = {};
     this.fieldValidators = {};
     this.actions = {};
   }

--- a/src/app/json-schema-example/visibility-binding-example-schema.json
+++ b/src/app/json-schema-example/visibility-binding-example-schema.json
@@ -1,0 +1,182 @@
+{
+  "type": "object",
+  "description": "Some fields will only show if some condition do apply:",
+  "properties": {
+    "description1": {
+      "type": "object",
+      "title": "FIELD 1",
+      "description": "Is only visible if car #1 exists with name 'fiat'",
+      "properties": {}
+    },
+    "description2": {
+      "type": "object",
+      "title": "FIELD 2",
+      "description": "Is only visible if car #2 exists with name 'renault'",
+      "properties": {}
+    },
+    "description3": {
+      "type": "object",
+      "title": "FIELD 3",
+      "description": "Is only visible if car #2 exists and tire #3 is named 'michelin'",
+      "properties": {}
+    },
+    "description4": {
+      "type": "object",
+      "title": "FIELD 4",
+      "description": "Is only visible if any car exists and tire #2 is named 'michelin'",
+      "properties": {}
+    },
+    "spacer 1": {
+      "type": "object",
+      "title": " ",
+      "description": " ",
+      "properties": {}
+    },
+    "fields": {
+      "type": "object",
+      "title": "Fields with visibility bindings",
+      "properties": {
+        "field1": {
+          "type": "string",
+          "title": "Field 1",
+          "description": " This field is only visible if car #1 exists with name 'fiat'",
+          "default": "You named the 1st car FIAT",
+          "visibleIf": {
+            "/garage/cars/0/name": [
+              "fiat"
+            ]
+          }
+        },
+        "field2": {
+          "type": "string",
+          "title": "Field 2",
+          "description": " This field is only visible if car #2 exists with name 'renault'",
+          "default": "You named the 2nd car RENAULT",
+          "visibleIf": {
+            "/garage/cars/1/name": [
+              "renault"
+            ]
+          }
+        },
+        "field3": {
+          "type": "string",
+          "title": "Field 3",
+          "description": " This field is only visible if car #2 exists and tire #3 is named 'michelin'",
+          "default": "You named the 3rd tire of the 2nd car MICHELIN",
+          "visibleIf": {
+            "/garage/cars/1/tires/2/name": [
+              "michelin"
+            ]
+          }
+        },
+        "field4": {
+          "type": "string",
+          "title": "Field 4",
+          "description": " This field is only visible if any car exists and tire #2 is named 'michelin'",
+          "default": "You named the 2nd tire of any car/s MICHELIN",
+          "TODO VISIBILITY-BINDINGS (issue #258) [IN PROGRESS] ": "TODO::// THIS ONLY WILL WORK PROPER IF THE OTHER VISIBLE IF ARE DEACTIVATED",
+          "visibleIf": {
+            "/garage/cars/*/tires/1/name": [
+              "michelin"
+            ]
+          }
+        }
+      }
+    },
+    "spacer 2": {
+      "type": "object",
+      "title": " ",
+      "description": " ",
+      "properties": {}
+    },
+    "garage": {
+      "type": "object",
+      "title": "Garage",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Garage name"
+        },
+        "cars": {
+          "title": "Cars",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Car",
+            "properties": {
+              "name": {
+                "widget": "select",
+                "type": "string",
+                "title": "Car name",
+                "oneOf": [
+                  {
+                    "enum": [
+                      ""
+                    ],
+                    "description": "Select car name"
+                  },
+                  {
+                    "enum": [
+                      "fiat"
+                    ],
+                    "description": "FIAT"
+                  },
+                  {
+                    "enum": [
+                      "renault"
+                    ],
+                    "description": "Renault"
+                  }
+                ]
+              },
+              "tires": {
+                "title": "Tires",
+                "type": "array",
+                "maxItems": 4,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "widget": "select",
+                      "type": "string",
+                      "oneOf": [
+                        {
+                          "enum": [
+                            ""
+                          ],
+                          "description": "Select tire name"
+                        },
+                        {
+                          "enum": [
+                            "michelin"
+                          ],
+                          "description": "Michelin"
+                        },
+                        {
+                          "enum": [
+                            "good year"
+                          ],
+                          "description": "Good Year"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "descriptionTires": {
+                "type": "object",
+                "description": "Press the above buttons 'Add' or 'Remove' to add or remove tires",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "descriptionCars": {
+          "type": "object",
+          "description": "Press the above buttons 'Add' or 'Remove' to add or remove cars",
+          "properties": {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
... and not yet existing array-items or properties using a property-bindings-registry

This pull request addresses the issue named in #258 

The issue mainly points to the missing feature to address items that do not exists when the schema gets processed to create the from.

So this pull request implements a property-binding-registry where all path and targets from any not yet existing property's `visibileIf` bindings are store to.

When a property is added to a `formProperty` the visibility binding will be re-processed.

Enables visibility paths like 
```
   /property1/array/1/name
   /property1/array/*/name
   /property1/array/*/item/*/name
   /property1/array/*/item/1/name
```