### PR TITLE
Select support enum as option

### DIFF
--- a/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
@@ -14,7 +14,12 @@ import { ControlWidget } from '../../widget';
 	</span>
 
 	<select *ngIf="schema.type!='array'" [formControl]="control" [attr.name]="name" [disabled]="schema.readOnly" class="form-control">
-		<option *ngFor="let option of schema.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
+		<ng-container *ngIf="schema.oneOf; else use_enum">
+			<option *ngFor="let option of schema.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
+		</ng-container>
+		<ng-template #use_enum>
+			<option *ngFor="let option of schema.enum" [ngValue]="option" >{{option}}</option>
+		</ng-template>
 	</select>
 
 	<select *ngIf="schema.type==='array'" multiple [formControl]="control" [attr.name]="name" [disabled]="schema.readOnly" class="form-control">

--- a/src/app/json-schema-example/json-schema-example.component.ts
+++ b/src/app/json-schema-example/json-schema-example.component.ts
@@ -34,10 +34,10 @@ export class JsonSchemaExampleComponent implements OnInit, OnDestroy {
   private subs: Subscription;
 
   samples = [
-    {label: 'Sample 1 - General', event: this.changeSchemaFirst, selected: false},
+    {label: 'Sample 1 - General', event: this.changeSchemaFirst, selected: true},
     {label: 'Sample 2 - Custom bindings', event: this.changeSchemaWithBindings, selected: false},
     {label: 'Sample 3 - Otherschema', event: this.changeSchemaOtherschema, selected: false},
-    {label: 'Sample 4 - Visibility binding', event: this.changeSchemaVisibilityBinding, selected: true},
+    {label: 'Sample 4 - Visibility binding', event: this.changeSchemaVisibilityBinding, selected: false},
   ];
 
   constructor(

--- a/src/app/json-schema-example/otherschema.json
+++ b/src/app/json-schema-example/otherschema.json
@@ -12,7 +12,8 @@
     {
       "fields": [
         "author",
-        "language"
+        "language",
+        "version"
       ],
       "id": "settings",
       "title": "Settings"
@@ -43,6 +44,25 @@
         {"enum": ["fr"], "description": "French"}
       ],
       "title": "Language",
+      "type": "string",
+      "widget": "select"
+    },
+    "version": {
+      "description": "",
+      "enum": [
+        "2.0",
+        "1.9",
+        "1.8",
+        "1.7",
+        "1.6",
+        "1.5",
+        "1.4",
+        "1.3",
+        "1.2",
+        "1.1",
+        "1.0"
+      ],
+      "title": "Version",
       "type": "string",
       "widget": "select"
     }


### PR DESCRIPTION
Allow setting `enum` as options for the `select` widget
fixes #221