### PR TITLE
add support for expression in visibleIf condition #fixes 228

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ export class AppComponent {
 ### Conditional fields
 It is possible to make the presence of a field depends on another field's value.
 To achieve this you just have to add a `visibleIf` property to a field's definition.
-Adding the value $ANY$ to the array of conditional values,will make the field visible for any value inserted.
+Adding the value `$ANY$` to the array of conditional values,will make the field visible for any value inserted.
 
 ```js
 @Component({
@@ -632,6 +632,32 @@ e.g
         ]
       }
 ```
+
+**Expressions**
+
+Expressions allow a more complex `visibleIf` condition related to the involded fields.  
+To use an expression the value of the item  
+in the conditional array must start with `$EXP$`.  
+When processing the expression a context is available containing  
+a `source` and a `target` object.  
+Where `source` is the `FormProperty` that has the `visibleIf` condition defined  
+and `target` is the `FormProperty` that has been defined by the `path`.
+
+```
+  "myField" : { // SOURCE
+    "visibleIf": {
+          "oneOf": [
+            {
+              "/person/1/age": // TARGET
+              [
+                "$EXP$ target.value < 18"
+              ]
+            }
+          ]
+        }
+   }
+```
+
 
 #### Hidden fields
 When a field has been made invisible by the condition `visibleIf`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4425,8 +4425,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4447,14 +4446,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4469,20 +4466,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4599,8 +4593,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4612,7 +4605,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4627,7 +4619,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4635,14 +4626,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4661,7 +4650,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4742,8 +4730,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4755,7 +4742,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4841,8 +4827,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4878,7 +4863,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4898,7 +4882,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4942,14 +4925,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6282,6 +6263,11 @@
       "requires": {
         "colors": "1.1.2"
       }
+    },
+    "jexl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jexl/-/jexl-2.1.1.tgz",
+      "integrity": "sha512-a+dZiuYIKl0nPYdAe7sJ8D/bCAbemwLjLypcT2brXtft/Mi3titp1QRCpTkaHrp+qeno8DKFxVpVKYNvw1AV3A=="
     },
     "js-base64": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/router": "~8.0.3",
     "bootstrap": "^4.1.3",
     "core-js": "^2.5.4",
+    "jexl": "^2.1.1",
     "ngx-schema-form": "file:projects/schema-form",
     "rxjs": "^6.5.2",
     "z-schema": "^3.24.1",

--- a/projects/schema-form/package.json
+++ b/projects/schema-form/package.json
@@ -25,7 +25,8 @@
     "Daniele Pecora <daniele.pecora@googlemail.com>"
   ],
   "dependencies": {
-    "z-schema": "^3.17.0"
+    "z-schema": "^3.17.0",
+    "jexl": "^2.1.1"
   },
   "peerDependencies": {
     "@angular/common": ">=6 <=8.1",

--- a/projects/schema-form/src/lib/expression-compiler-factory.ts
+++ b/projects/schema-form/src/lib/expression-compiler-factory.ts
@@ -1,0 +1,55 @@
+export abstract class ExpressionCompilerFactory {
+    public abstract createExpressionCompiler(): ExpressionCompiler;
+    public abstract createExpressionCompilerVisibilityIf(): ExpressionCompilerVisibilityIf;
+}
+
+export interface ExpressionCompiler {
+    evaluate(expression: string, context: object): any;
+}
+
+export interface ExpressionCompilerVisibilityIf {
+    evaluate(expression: string, context: ExpressionContextVisibilitIf): any;
+}
+/**
+ * UseCase:<br/>
+ * When evaluating the expression of a <code>visibilityIf</code> condition
+ * an instance of this definition will be passed as context.<br/>
+ * This will give access to the source and target <code>FormProperty</code>.
+ */
+export interface ExpressionContextVisibilitIf {
+    /**
+     * The source property which has the <code>visibilityIf</code> defined
+     */
+    source: FormProperty
+    /**
+     * The target property given with the <code>visibilityIf</code>
+     * <em>path</em> property
+     */
+    target: FormProperty
+}
+
+
+import * as JEXL from 'jexl';
+import { FormProperty } from './model';
+
+export class JEXLExpressionCompilerFactory extends ExpressionCompilerFactory {
+    public createExpressionCompiler(): ExpressionCompiler {
+        return new JEXLExpressionCompiler();
+    }
+
+    public createExpressionCompilerVisibilityIf(): ExpressionCompilerVisibilityIf {
+        return new JEXLExpressionCompilerVisibiltyIf();
+    }
+}
+
+export class JEXLExpressionCompiler implements ExpressionCompiler {
+    evaluate(expression: string, context: object = {}): any {
+        return JEXL.evalSync(expression, context)
+    }
+}
+
+export class JEXLExpressionCompilerVisibiltyIf implements ExpressionCompilerVisibilityIf {
+    evaluate(expression: string, context: ExpressionContextVisibilitIf = { source: {} as FormProperty, target: {} as FormProperty }): any {
+        return JEXL.evalSync(expression, context)
+    }
+}

--- a/projects/schema-form/src/lib/form.component.ts
+++ b/projects/schema-form/src/lib/form.component.ts
@@ -23,9 +23,10 @@ import {SchemaValidatorFactory} from './schemavalidatorfactory';
 import {WidgetFactory} from './widgetfactory';
 import {TerminatorService} from './terminator.service';
 import {PropertyBindingRegistry} from './property-binding-registry';
+import { ExpressionCompilerFactory } from './expression-compiler-factory';
 
-export function useFactory(schemaValidatorFactory, validatorRegistry, propertyBindingRegistry) {
-  return new FormPropertyFactory(schemaValidatorFactory, validatorRegistry, propertyBindingRegistry);
+export function useFactory(schemaValidatorFactory, validatorRegistry, propertyBindingRegistry, expressionCompilerFactory) {
+  return new FormPropertyFactory(schemaValidatorFactory, validatorRegistry, propertyBindingRegistry, expressionCompilerFactory);
 }
 
 @Component({
@@ -45,7 +46,7 @@ export function useFactory(schemaValidatorFactory, validatorRegistry, propertyBi
     {
       provide: FormPropertyFactory,
       useFactory: useFactory,
-      deps: [SchemaValidatorFactory, ValidatorRegistry, PropertyBindingRegistry]
+      deps: [SchemaValidatorFactory, ValidatorRegistry, PropertyBindingRegistry, ExpressionCompilerFactory]
     },
     TerminatorService,
     {

--- a/projects/schema-form/src/lib/model/arrayproperty.ts
+++ b/projects/schema-form/src/lib/model/arrayproperty.ts
@@ -2,16 +2,18 @@ import {FormProperty, PropertyGroup} from './formproperty';
 import {FormPropertyFactory} from './formpropertyfactory';
 import {SchemaValidatorFactory} from '../schemavalidatorfactory';
 import {ValidatorRegistry} from './validatorregistry';
+import { ExpressionCompilerFactory } from '../expression-compiler-factory';
 
 export class ArrayProperty extends PropertyGroup {
 
   constructor(private formPropertyFactory: FormPropertyFactory,
               schemaValidatorFactory: SchemaValidatorFactory,
               validatorRegistry: ValidatorRegistry,
+              expressionCompilerFactory: ExpressionCompilerFactory,
               schema: any,
               parent: PropertyGroup,
               path: string) {
-    super(schemaValidatorFactory, validatorRegistry, schema, parent, path);
+    super(schemaValidatorFactory, validatorRegistry, expressionCompilerFactory, schema, parent, path);
   }
 
   addItem(value: any = null): FormProperty {

--- a/projects/schema-form/src/lib/model/atomicproperties.spec.ts
+++ b/projects/schema-form/src/lib/model/atomicproperties.spec.ts
@@ -13,6 +13,7 @@ import {
 import {
   ZSchemaValidatorFactory
 } from '../schemavalidatorfactory';
+import { JEXLExpressionCompilerFactory } from '../expression-compiler-factory';
 
 class AtomicPropertyImpl extends AtomicProperty {
 
@@ -24,13 +25,14 @@ class AtomicPropertyImpl extends AtomicProperty {
 describe('Atomic properties', () => {
   let A_SCHEMA_VALIDATOR_FACTORY = new ZSchemaValidatorFactory();
   let A_VALIDATOR_REGISTRY = new ValidatorRegistry();
+  let A_EXPRESSION_COMPILER_FACTORY = new JEXLExpressionCompilerFactory();
 
   describe('AtomicProperty', () => {
     let THE_PROPERTY_SCHEMA = {};
     let atomicProperty: AtomicProperty;
 
     beforeEach(() => {
-      atomicProperty = new AtomicPropertyImpl(A_SCHEMA_VALIDATOR_FACTORY, A_VALIDATOR_REGISTRY, THE_PROPERTY_SCHEMA, null, '');
+      atomicProperty = new AtomicPropertyImpl(A_SCHEMA_VALIDATOR_FACTORY, A_VALIDATOR_REGISTRY, A_EXPRESSION_COMPILER_FACTORY, THE_PROPERTY_SCHEMA, null, '');
     });
 
     it('reset with no argument and default value in schema should use the default value', () => {
@@ -39,6 +41,7 @@ describe('Atomic properties', () => {
       let atomicPropertyWithDefault = new AtomicPropertyImpl(
         A_SCHEMA_VALIDATOR_FACTORY,
         A_VALIDATOR_REGISTRY,
+        A_EXPRESSION_COMPILER_FACTORY,
         A_SCHEMA_WITH_DEFAULT,
         null,
         ''
@@ -67,6 +70,7 @@ describe('Atomic properties', () => {
       let property = new NumberProperty(
         A_SCHEMA_VALIDATOR_FACTORY,
         A_VALIDATOR_REGISTRY,
+        A_EXPRESSION_COMPILER_FACTORY,
         AN_INT_PROPERTY_SCHEMA_WITHOUT_MINIMUM,
         null,
         ''

--- a/projects/schema-form/src/lib/model/formproperty.spec.ts
+++ b/projects/schema-form/src/lib/model/formproperty.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../schemavalidatorfactory';
 
 import { ValidatorRegistry } from './validatorregistry';
+import { JEXLExpressionCompilerFactory } from '../expression-compiler-factory';
 
 class FormPropertyImpl extends FormProperty {
 
@@ -29,6 +30,7 @@ class PropertyGroupImpl extends PropertyGroup {
 describe('FormProperty', () => {
   let THE_SCHEMA_VALIDATOR_FACTORY =  new ZSchemaValidatorFactory();
   let THE_VALIDATOR_REGISTRY = new ValidatorRegistry();
+  let THE_EXPRESSION_COMPILER_FACTORY = new JEXLExpressionCompilerFactory();
   let THE_PROPERTY_SCHEMA = {};
   let THE_PARENT_PROPERTY_SCHEMA = {};
   let THE_VALIDATOR;
@@ -43,6 +45,7 @@ describe('FormProperty', () => {
     propertyGroup = new PropertyGroupImpl(
       THE_SCHEMA_VALIDATOR_FACTORY,
       THE_VALIDATOR_REGISTRY,
+      THE_EXPRESSION_COMPILER_FACTORY,
       THE_PARENT_PROPERTY_SCHEMA,
       null,
       ''
@@ -51,6 +54,7 @@ describe('FormProperty', () => {
     formProperty = new FormPropertyImpl(
       THE_SCHEMA_VALIDATOR_FACTORY,
       THE_VALIDATOR_REGISTRY,
+      THE_EXPRESSION_COMPILER_FACTORY,
       THE_PROPERTY_SCHEMA,
       propertyGroup,
       ''
@@ -85,6 +89,7 @@ describe('FormProperty', () => {
       let orphanFormProperty = new FormPropertyImpl(
         THE_SCHEMA_VALIDATOR_FACTORY,
         THE_VALIDATOR_REGISTRY,
+        THE_EXPRESSION_COMPILER_FACTORY,
         THE_PROPERTY_SCHEMA,
         propertyGroup,
         ''

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -4,9 +4,11 @@ import {distinctUntilChanged, map} from 'rxjs/operators';
 import {SchemaValidatorFactory} from '../schemavalidatorfactory';
 import {ValidatorRegistry} from './validatorregistry';
 import {PropertyBindingRegistry} from '../property-binding-registry';
+import { ExpressionCompilerFactory, ExpressionCompilerVisibilityIf } from '../expression-compiler-factory';
 
 export abstract class FormProperty {
   public schemaValidator: Function;
+  public expressionCompilerVisibiltyIf: ExpressionCompilerVisibilityIf;
 
   _value: any = null;
   _errors: any = null;
@@ -22,10 +24,12 @@ export abstract class FormProperty {
 
   constructor(schemaValidatorFactory: SchemaValidatorFactory,
               private validatorRegistry: ValidatorRegistry,
+              expressionCompilerFactory: ExpressionCompilerFactory,
               public schema: any,
               parent: PropertyGroup,
               path: string) {
     this.schemaValidator = schemaValidatorFactory.createValidatorFn(this.schema);
+    this.expressionCompilerVisibiltyIf = expressionCompilerFactory.createExpressionCompilerVisibilityIf();
 
     this._parent = parent;
     if (parent) {
@@ -174,6 +178,38 @@ export abstract class FormProperty {
     }
   }
 
+  /**
+   * Making use of the expression compiler for the <code>visibleIf</code> condition
+   */
+  private __evaluateVisibilityIf(
+    sourceProperty: FormProperty,
+    targetProperty: FormProperty,
+    dependencyPath: string,
+    value: any = '',
+    expression: string = ''): boolean {
+    try {
+      let valid = false
+      if (expression.indexOf('$ANY$') !== -1) {
+        valid = value.length > 0;
+      } else if ((expression||[]).toString().indexOf('$EXP$') === 0) {
+        // since visibleIf condition values are an array... we must do this
+        const expArray = Array.isArray(expression) ? expression : (expression ? [expression] : [])
+        for (const expString of expArray) {
+          const _expresssion = expString.substring('$EXP$'.length);
+          valid = true === this.expressionCompilerVisibiltyIf.evaluate(_expresssion, {
+            source: sourceProperty,
+            target: targetProperty
+          })
+        }
+      } else {
+        valid = value.indexOf(expression) !== -1;
+      }
+      return valid
+    } catch (error) {
+      console.error('Error processing "VisibileIf" expression for path: ', dependencyPath, 'source:', sourceProperty, 'target:', targetProperty, 'value:', value, error)
+    }
+  }
+
   private __bindVisibility(): boolean {
     /**
      * <pre>
@@ -208,13 +244,7 @@ export abstract class FormProperty {
                     let valueCheck;
                     if (this.schema.visibleIf.oneOf) {
                       valueCheck = property.valueChanges.pipe(map(
-                        value => {
-                          if (visibleIf[dependencyPath].indexOf('$ANY$') !== -1) {
-                            return value.length > 0;
-                          } else {
-                            return visibleIf[dependencyPath].indexOf(value) !== -1;
-                          }
-                        }
+                        value => this.__evaluateVisibilityIf(this, property, dependencyPath, value, visibleIf[dependencyPath])
                       ));
                     } else if (this.schema.visibleIf.allOf) {
                       const _chk = (value) => {
@@ -222,15 +252,7 @@ export abstract class FormProperty {
                           for (const depPath of Object.keys(item)) {
                             const prop = this.searchProperty(depPath);
                             const propVal = prop._value;
-                            let valid = false;
-                            if (item[depPath].indexOf('$ANY$') !== -1) {
-                              valid = propVal.length > 0;
-                            } else {
-                              valid = item[depPath].indexOf(propVal) !== -1;
-                            }
-                            if (!valid) {
-                              return false;
-                            }
+                            return this.__evaluateVisibilityIf(this, prop, dependencyPath, propVal, item[depPath]);
                           }
                         }
                         return true;
@@ -278,13 +300,7 @@ export abstract class FormProperty {
             for (const property of properties) {
               if (property) {
                 const valueCheck = property.valueChanges.pipe(map(
-                  value => {
-                    if (visibleIf[dependencyPath].indexOf('$ANY$') !== -1) {
-                      return value.length > 0;
-                    } else {
-                      return visibleIf[dependencyPath].indexOf(value) !== -1;
-                    }
-                  }
+                  value => this.__evaluateVisibilityIf(this, property, dependencyPath, value, visibleIf[dependencyPath])
                 ));
                 const visibilityCheck = property._visibilityChanges;
                 const and = combineLatest([valueCheck, visibilityCheck], (v1, v2) => v1 && v2);

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -200,6 +200,9 @@ export abstract class FormProperty {
             source: sourceProperty,
             target: targetProperty
           })
+          if (valid) {
+            break
+          }
         }
       } else {
         valid = value.indexOf(expression) !== -1;

--- a/projects/schema-form/src/lib/model/formpropertyfactory.ts
+++ b/projects/schema-form/src/lib/model/formpropertyfactory.ts
@@ -7,11 +7,13 @@ import {ArrayProperty} from './arrayproperty';
 import {SchemaValidatorFactory} from '../schemavalidatorfactory';
 import {ValidatorRegistry} from './validatorregistry';
 import {PropertyBindingRegistry} from '../property-binding-registry';
+import { ExpressionCompilerFactory } from '../expression-compiler-factory';
 
 export class FormPropertyFactory {
 
   constructor(private schemaValidatorFactory: SchemaValidatorFactory, private validatorRegistry: ValidatorRegistry,
-              private propertyBindingRegistry: PropertyBindingRegistry) {
+              private propertyBindingRegistry: PropertyBindingRegistry,
+              private expressionCompilerFactory: ExpressionCompilerFactory) {
   }
 
   createProperty(schema: any, parent: PropertyGroup = null, propertyId?: string): FormProperty {
@@ -46,19 +48,19 @@ export class FormPropertyFactory {
       switch (schema.type) {
         case 'integer':
         case 'number':
-          newProperty = new NumberProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          newProperty = new NumberProperty(this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path);
           break;
         case 'string':
-          newProperty = new StringProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          newProperty = new StringProperty(this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path);
           break;
         case 'boolean':
-          newProperty = new BooleanProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          newProperty = new BooleanProperty(this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path);
           break;
         case 'object':
-          newProperty = new ObjectProperty(this, this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          newProperty = new ObjectProperty(this, this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path);
           break;
         case 'array':
-          newProperty = new ArrayProperty(this, this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          newProperty = new ArrayProperty(this, this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path);
           break;
         default:
           throw new TypeError(`Undefined type ${schema.type}`);

--- a/projects/schema-form/src/lib/model/objectproperty.spec.ts
+++ b/projects/schema-form/src/lib/model/objectproperty.spec.ts
@@ -7,13 +7,15 @@ import {
 
 import { ValidatorRegistry } from './validatorregistry';
 import {PropertyBindingRegistry} from '../property-binding-registry';
+import { JEXLExpressionCompilerFactory } from '../expression-compiler-factory';
 
 describe('ObjectProperty', () => {
 
   let A_VALIDATOR_REGISTRY = new ValidatorRegistry();
   let A_SCHEMA_VALIDATOR_FACTORY = new ZSchemaValidatorFactory();
   let A_PROPERTY_BINDING_REGISTRY=new PropertyBindingRegistry();
-  let A_FORM_PROPERTY_FACTORY = new FormPropertyFactory(A_SCHEMA_VALIDATOR_FACTORY, A_VALIDATOR_REGISTRY, A_PROPERTY_BINDING_REGISTRY);
+  let A_EXPRESSION_COMPILER_FACTORY = new JEXLExpressionCompilerFactory();
+  let A_FORM_PROPERTY_FACTORY = new FormPropertyFactory(A_SCHEMA_VALIDATOR_FACTORY, A_VALIDATOR_REGISTRY, A_PROPERTY_BINDING_REGISTRY, A_EXPRESSION_COMPILER_FACTORY);
 
 
   let THE_OBJECT_SCHEMA = {
@@ -33,6 +35,7 @@ describe('ObjectProperty', () => {
       A_FORM_PROPERTY_FACTORY,
       A_SCHEMA_VALIDATOR_FACTORY,
       A_VALIDATOR_REGISTRY,
+      A_EXPRESSION_COMPILER_FACTORY,
       THE_OBJECT_SCHEMA,
       null,
       ''

--- a/projects/schema-form/src/lib/model/objectproperty.ts
+++ b/projects/schema-form/src/lib/model/objectproperty.ts
@@ -2,6 +2,7 @@ import {PropertyGroup} from './formproperty';
 import {FormPropertyFactory} from './formpropertyfactory';
 import {SchemaValidatorFactory} from '../schemavalidatorfactory';
 import {ValidatorRegistry} from './validatorregistry';
+import { ExpressionCompilerFactory } from '../expression-compiler-factory';
 
 export class ObjectProperty extends PropertyGroup {
 
@@ -10,10 +11,11 @@ export class ObjectProperty extends PropertyGroup {
   constructor(private formPropertyFactory: FormPropertyFactory,
               schemaValidatorFactory: SchemaValidatorFactory,
               validatorRegistry: ValidatorRegistry,
+              expressionCompilerFactory: ExpressionCompilerFactory,
               schema: any,
               parent: PropertyGroup,
               path: string) {
-    super(schemaValidatorFactory, validatorRegistry, schema, parent, path);
+    super(schemaValidatorFactory, validatorRegistry, expressionCompilerFactory, schema, parent, path);
     this.createProperties();
   }
 

--- a/projects/schema-form/src/lib/schema-form.module.ts
+++ b/projects/schema-form/src/lib/schema-form.module.ts
@@ -27,6 +27,7 @@ import {
 import {WidgetRegistry} from './widgetregistry';
 import {SchemaValidatorFactory, ZSchemaValidatorFactory} from './schemavalidatorfactory';
 import {FormElementComponentAction} from './formelement.action.component';
+import {ExpressionCompilerFactory, JEXLExpressionCompilerFactory} from './expression-compiler-factory';
 
 const moduleProviders = [
   {
@@ -36,6 +37,10 @@ const moduleProviders = [
   {
     provide: SchemaValidatorFactory,
     useClass: ZSchemaValidatorFactory
+  },
+  {
+    provide: ExpressionCompilerFactory,
+    useClass: JEXLExpressionCompilerFactory
   }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,7 +33,7 @@ import {
     ReactiveFormsModule,
     HttpClientModule,
     RouterModule.forRoot(routes),
-    SchemaFormModule,
+    SchemaFormModule.forRoot(),
     TemplateSchemaModule
   ],
   providers: [

--- a/src/app/json-schema-example/visibility-binding-example-schema.json
+++ b/src/app/json-schema-example/visibility-binding-example-schema.json
@@ -26,6 +26,12 @@
       "description": "Is only visible if any car exists and tire #2 is named 'michelin'",
       "properties": {}
     },
+    "description5": {
+      "type": "object",
+      "title": "FIELD 5",
+      "description": "Is only visible if any car has space for more than 3 passengers",
+      "properties": {}
+    },
     "spacer 1": {
       "type": "object",
       "title": " ",
@@ -79,6 +85,17 @@
               "michelin"
             ]
           }
+        },
+        "field5": {
+          "type": "string",
+          "title": "Field 5",
+          "description": " This field is only visible if any car has space for more than 3 passengers",
+          "default": "One car has space for more than 3 passengers",
+          "visibleIf": {
+            "/garage/cars/*/space": [
+              "$EXP$ target.value > 3"
+            ]
+          }
         }
       }
     },
@@ -127,6 +144,13 @@
                     "description": "Renault"
                   }
                 ]
+              },
+              "space": {
+                "type": "number",
+                "title": "How many passengers",
+                "description": "How many passengers do fit in this car?",
+                "min": 3,
+                "max": 5
               },
               "tires": {
                 "title": "Tires",


### PR DESCRIPTION
VisibleIf condition supports now expressions.  
The execution is very sandboxed, since the context is not global and provided by the implementation.  
To make this request a non breaking change, the expression used must be initiated with the prefix `$EXP$`

e.g:  
```
  "myField" : { // SOURCE
    "visibleIf": {
          "oneOf": [
            {
              "/person/1/age": // TARGET
              [
                "$EXP$ target.value < 18"
              ]
            }
          ]
        }
   }
```


As expression parser and compiler **JEXL** is used.   
See it on git https://github.com/TomFrost/jexl .
