### PR TITLE
hide or disable array widget add and remove button

### DIFF
--- a/projects/schema-form/src/lib/defaultwidgets/array/array.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/array/array.widget.ts
@@ -12,26 +12,58 @@ import { FormProperty } from '../../model';
 	<span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
 	<div *ngFor="let itemProperty of formProperty.properties">
 		<sf-form-element [formProperty]="itemProperty"></sf-form-element>
-		<button (click)="removeItem(itemProperty)" class="btn btn-default array-remove-button">
+		<button (click)="removeItem(itemProperty)" class="btn btn-default array-remove-button"
+			[disabled]="isAddButtonDisabled()" 
+			*ngIf="!(schema.hasOwnProperty('minItems') && schema.hasOwnProperty('maxItems') && schema.minItems === schema.maxItems)"
+			>
 			<span class="glyphicon glyphicon-minus" aria-hidden="true"></span> Remove
 		</button>
 	</div>
-	<button (click)="addItem()" class="btn btn-default array-add-button">
+	<button (click)="addItem()" class="btn btn-default array-add-button"
+		[disabled]="isRemoveButtonDisabled()"
+		*ngIf="!(schema.hasOwnProperty('minItems') && schema.hasOwnProperty('maxItems') && schema.minItems === schema.maxItems)"
+	>
 		<span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add
 	</button>
 </div>`
 })
 export class ArrayWidget extends ArrayLayoutWidget {
+  buttonDisabledAdd:boolean
+  buttonDisabledRemove:boolean
 
   addItem() {
-    this.formProperty.addItem();
+	this.formProperty.addItem();
+	this.updateButtonDisabledState()
   }
 
   removeItem(item: FormProperty) {
-    this.formProperty.removeItem(item);
+	this.formProperty.removeItem(item);
+	this.updateButtonDisabledState()
   }
 
   trackByIndex(index: number, item: any) {
     return index;
   }
+
+	updateButtonDisabledState() {
+		this.buttonDisabledAdd = this.isAddButtonDisabled()
+		this.buttonDisabledRemove = this.isRemoveButtonDisabled()
+	}
+	isAddButtonDisabled() {
+		if (this.schema.hasOwnProperty('maxItems') && Array.isArray(this.formProperty.properties)) {
+			if (this.formProperty.properties.length >= this.schema.maxItems) {
+				return true
+			}
+		}
+		return false
+	}
+
+	isRemoveButtonDisabled() {
+		if (this.schema.hasOwnProperty('minItems') && Array.isArray(this.formProperty.properties)) {
+			if (this.formProperty.properties.length <= this.schema.minItems) {
+				return true
+			}
+		}
+		return false
+	}
 }

--- a/projects/schema-form/src/lib/defaultwidgets/array/array.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/array/array.widget.ts
@@ -13,14 +13,14 @@ import { FormProperty } from '../../model';
 	<div *ngFor="let itemProperty of formProperty.properties">
 		<sf-form-element [formProperty]="itemProperty"></sf-form-element>
 		<button (click)="removeItem(itemProperty)" class="btn btn-default array-remove-button"
-			[disabled]="isAddButtonDisabled()" 
+			[disabled]="isRemoveButtonDisabled()" 
 			*ngIf="!(schema.hasOwnProperty('minItems') && schema.hasOwnProperty('maxItems') && schema.minItems === schema.maxItems)"
 			>
 			<span class="glyphicon glyphicon-minus" aria-hidden="true"></span> Remove
 		</button>
 	</div>
 	<button (click)="addItem()" class="btn btn-default array-add-button"
-		[disabled]="isRemoveButtonDisabled()"
+		[disabled]="isAddButtonDisabled()"
 		*ngIf="!(schema.hasOwnProperty('minItems') && schema.hasOwnProperty('maxItems') && schema.minItems === schema.maxItems)"
 	>
 		<span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add


### PR DESCRIPTION
in relation to the settings of 'maxItems' and 'minItems' in schema.
fixes #293

This is how it will set the buttons `disabled` or hide them:
Button **ADD** will be
- disabled if `maxItems` is reached
- hidden if `maxItems` equals `minItems` which means a fixed array length is only allowed

Button **REMOVE** will be
- disabled if `minItems` is reached
- hidden if `maxItems` equals `minItems` which means a fixed array length is only allowed
