### PR TITLE
remove unused deprecated dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -811,14 +811,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "@angular/http": {
-      "version": "7.2.15",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-7.2.15.tgz",
-      "integrity": "sha512-TR7PEdmLWNIre3Zn8lvyb4lSrvPUJhKLystLnp4hBMcWsJqq5iK8S3bnlR4viZ9HMlf7bW7+Hm4SI6aB3tdUtw==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "@angular/language-service": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-8.0.3.tgz",
@@ -7375,10 +7367,7 @@
       }
     },
     "ngx-schema-form": {
-      "version": "file:projects/schema-form",
-      "requires": {
-        "z-schema": "^3.17.0"
-      }
+      "version": "file:projects/schema-form"
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@angular/compiler": "~8.0.3",
     "@angular/core": "~8.0.3",
     "@angular/forms": "~8.0.3",
-    "@angular/http": "^7.2.15",
     "@angular/platform-browser": "~8.0.3",
     "@angular/platform-browser-dynamic": "~8.0.3",
     "@angular/router": "~8.0.3",


### PR DESCRIPTION
Mainly the unused dependecy `@angular/http` has been removed from demo project.  
`@angular/http` is any also not available anymore in Angular 8.