### PR TITLE
fix 'TypeError: value.indexOf is not a function' when using visibleIf…

### DIFF
--- a/projects/schema-form/src/lib/expression-compiler-factory.ts
+++ b/projects/schema-form/src/lib/expression-compiler-factory.ts
@@ -50,6 +50,6 @@ export class JEXLExpressionCompiler implements ExpressionCompiler {
 
 export class JEXLExpressionCompilerVisibiltyIf implements ExpressionCompilerVisibilityIf {
     evaluate(expression: string, context: ExpressionContextVisibilitIf = { source: {} as FormProperty, target: {} as FormProperty }): any {
-        return JEXL.evalSync(expression, context)
+        return new JEXL.Jexl().evalSync(expression, context)
     }
 }

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -190,7 +190,7 @@ export abstract class FormProperty {
     try {
       let valid = false
       if (expression.indexOf('$ANY$') !== -1) {
-        valid = value.length > 0;
+        valid = value && value.length > 0;
       } else if ((expression||[]).toString().indexOf('$EXP$') === 0) {
         // since visibleIf condition values are an array... we must do this
         const expArray = Array.isArray(expression) ? expression : (expression ? [expression] : [])
@@ -259,7 +259,7 @@ export abstract class FormProperty {
                         for (const item of this.schema.visibleIf.allOf) {
                           for (const depPath of Object.keys(item)) {
                             const prop = this.searchProperty(depPath);
-                            const propVal = prop._value;
+                            const propVal = prop.value;
                             if (!this.__evaluateVisibilityIf(this, prop, dependencyPath, propVal, item[depPath])) {
                               return false;
                             }

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -186,7 +186,7 @@ export abstract class FormProperty {
     targetProperty: FormProperty,
     dependencyPath: string,
     value: any = '',
-    expression: string = ''): boolean {
+    expression: string|string[] = ''): boolean {
     try {
       let valid = false
       if (expression.indexOf('$ANY$') !== -1) {
@@ -209,7 +209,12 @@ export abstract class FormProperty {
       }
       return valid
     } catch (error) {
-      console.error('Error processing "VisibileIf" expression for path: ', dependencyPath, 'source:', sourceProperty, 'target:', targetProperty, 'value:', value, error)
+      console.error('Error processing "VisibileIf" expression for path: ', dependencyPath,
+        `source - ${sourceProperty._canonicalPath}: `, sourceProperty,
+        `target - ${targetProperty._canonicalPath}: `, targetProperty,
+        'value:', value,
+        'expression: ', expression,
+        'error: ', error)
     }
   }
 
@@ -255,7 +260,9 @@ export abstract class FormProperty {
                           for (const depPath of Object.keys(item)) {
                             const prop = this.searchProperty(depPath);
                             const propVal = prop._value;
-                            return this.__evaluateVisibilityIf(this, prop, dependencyPath, propVal, item[depPath]);
+                            if (!this.__evaluateVisibilityIf(this, prop, dependencyPath, propVal, item[depPath])) {
+                              return false;
+                            }
                           }
                         }
                         return true;

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -205,7 +205,7 @@ export abstract class FormProperty {
           }
         }
       } else {
-        valid = value.indexOf(expression) !== -1;
+        valid = expression.indexOf(value) !== -1;
       }
       return valid
     } catch (error) {


### PR DESCRIPTION
Unfortunately this error will occurr when using simply style `visibleIf` condition.

This will be fixed with this pull request.

```
Error processing "VisibileIf" expression for path:  ... source: StringProperty {validatorRegistry: ValidatorRegistry, schema: {…}, _value: "", _errors: null, _valueChanges: BehaviorSubject, …} target: BooleanProperty {validatorRegistry: ValidatorRegistry, schema: {…}, _value: false, _errors: null, _valueChanges: BehaviorSubject, …} value: false TypeError: value.indexOf is not a function
    at StringProperty.push../node_modules/ngx-schema-form/fesm5/ngx-schema-form.js.FormProperty.__evaluateVisibilityIf (ngx-schema-form.js:393)
    at MapSubscriber.project (ngx-schema-form.js:606)
    at MapSubscriber.push../node_modules/rxjs/_esm5/internal/operators/map.js.MapSubscriber._next (map.js:35)
    at MapSubscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.Subscriber.next (Subscriber.js:53)
    at BehaviorSubject.push../node_modules/rxjs/_esm5/internal/Subject.js.Subject.next (Subject.js:47)
    at BehaviorSubject.push../node_modules/rxjs/_esm5/internal/BehaviorSubject.js.BehaviorSubject.next (BehaviorSubject.js:38)
    at BooleanProperty.push../node_modules/ngx-schema-form/fesm5/ngx-schema-form.js.FormProperty.updateValueAndValidity (ngx-schema-form.js:190)
    at BooleanProperty.push../node_modules/ngx-schema-form/fesm5/ngx-schema-form.js.AtomicProperty.reset (ngx-schema-form.js:1192)
    at ObjectProperty.push../node_modules/ngx-schema-form/fesm5/ngx-schema-form.js.ObjectProperty.resetProperties (ngx-schema-form.js:1377)
    at ObjectProperty.push../node_modules/ngx-schema-form/fesm5/ngx-schema-form.js.ObjectProperty.reset (ngx-schema-form.js:1363)
```