### PR TITLE
add support state inactive for options of radio or select widget

### DIFF
--- a/projects/schema-form/src/lib/defaultwidgets/radio/radio.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/radio/radio.widget.ts
@@ -9,7 +9,7 @@ import { ControlWidget } from '../../widget';
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
 	<div *ngFor="let option of schema.oneOf" class="radio">
 		<label class="horizontal control-label">
-			<input [formControl]="control" [attr.name]="name" value="{{option.enum[0]}}" type="radio"  [disabled]="schema.readOnly">
+			<input [formControl]="control" [attr.name]="name" value="{{option.enum[0]}}" type="radio"  [disabled]="schema.readOnly||option.readOnly">
 			{{option.description}}
 		</label>
 	</div>

--- a/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
@@ -23,7 +23,7 @@ import { ControlWidget } from '../../widget';
 	</select>
 
 	<select *ngIf="schema.type==='array'" multiple [formControl]="control" [attr.name]="name" [disabled]="schema.readOnly" class="form-control">
-		<option *ngFor="let option of schema.items.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
+		<option *ngFor="let option of schema.items.oneOf" [ngValue]="option.enum[0]" [disabled]="option.readOnly">{{option.description}}</option>
 	</select>
 
 	<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">


### PR DESCRIPTION
add support state inactive for options of radio or select widget by setting the single option `"readOnly":true`



Example:

```json
{
  "type": "object",
  "properties": {
    "radio": {
      "type": "string",
      "oneOf": [
        {
          "enum": [
            "a"
          ]
        },
        {
          "enum": [
            "b"
          ],
          "readOnly": true // option set inactive
        },
        {
          "enum": [
            "c"
          ]
        }
      ]
    },
    "select": {
      "type": "string",
      "oneOf": [
        {
          "enum": [
            "a"
          ]
        },
        {
          "enum": [
            "b"
          ],
          "readOnly": true // option set inactive
        },
        {
          "enum": [
            "c"
          ]
        }
      ]
    }
}
```

_Won' t work when using `enum` only as options._