### PR TITLE
allow custom properties in schema

### DIFF
--- a/projects/schema-form/src/lib/model/ISchema.ts
+++ b/projects/schema-form/src/lib/model/ISchema.ts
@@ -3,12 +3,16 @@ import {FieldType} from '../template-schema/field/field';
 export interface IOneOf {
   enum?: any[];
   description?: string;
+  /** allow additional properties */
+  [prop: string]: any;
 }
 
 export interface IWidget {
   id?: string;
   plugins?: string;
   toolbar?: string;
+  /** allow additional properties */
+  [prop: string]: any;
 }
 
 export interface IFieldSet {
@@ -17,12 +21,16 @@ export interface IFieldSet {
   name: string;
   description: string;
   fields: string[];
+  /** allow additional properties */
+  [prop: string]: any;
 }
 
 export interface IButton {
   id: string;
   label: string;
   widget?: string | object;
+  /** allow additional properties */
+  [prop: string]: any;
 }
 
 export interface IProperties {
@@ -50,5 +58,6 @@ export interface ISchema {
   format?: string;
   widget?: IWidget | any;
   fieldsets?: IFieldSet[];
+  /** allow additional properties */
   [prop: string]: any;
 }

--- a/projects/schema-form/src/lib/model/index.ts
+++ b/projects/schema-form/src/lib/model/index.ts
@@ -18,3 +18,5 @@ export * from './validatorregistry';
 
 export * from './schemapreprocessor';
 export * from './typemapping';
+
+export * from './ISchema';

--- a/projects/schema-form/src/public_api.ts
+++ b/projects/schema-form/src/public_api.ts
@@ -24,6 +24,14 @@ export {
   Validator,
   ValidatorRegistry,
   SchemaPreprocessor,
+  // <schema def>
+  IButton,
+  IFieldSet,
+  IOneOf,
+  IProperties,
+  ISchema,
+  IWidget
+  // </schema def>
 } from './lib/model';
 export {
   SchemaValidatorFactory,

--- a/src/app/json-schema-example/json-schema-example.component.ts
+++ b/src/app/json-schema-example/json-schema-example.component.ts
@@ -16,7 +16,7 @@ import binding_sample_bindings from './binding_sample_bindings';
 import visibility_binding_example from './visibility-binding-example-schema.json';
 
 import {AppService, AppData} from '../app.service';
-import {ISchema} from 'ngx-schema-form/src/lib/model/ISchema';
+import {ISchema} from 'ngx-schema-form';
 
 @Component({
   selector: 'sf-json-schema-example',


### PR DESCRIPTION
fix #340
Creating own UI Widget Library may requires extending of the actual schema definition with custom properties.
Since we are currently switching to Angular 9 now and our UI Widget Library makes excessive use of extending the schema we are really excited to see this published soon.
 :-)