### PR TITLE
fix: ngx form json schema definition

### DIFF
--- a/schema/ngx-schema-form-schema.json
+++ b/schema/ngx-schema-form-schema.json
@@ -4,8 +4,10 @@
   "$comment": "Definition of all types supported by ngx-schema-form",
   "title": "JSON Schema ngx-schema-form",
   "type": "object",
-  "$ref": "#/definitions/formWidgetType",
   "allOf": [
+    {
+      "$ref": "#/definitions/formWidgetType"
+    },
     {
       "$ref": "http://json-schema.org/draft-07/schema#"
     }

--- a/schema/ngx-schema-form-schema.json
+++ b/schema/ngx-schema-form-schema.json
@@ -208,6 +208,9 @@
               },
               {
                 "type": "null"
+              },
+              {
+                "type": "number"
               }
             ]
           }

--- a/schema/ngx-schema-form-schema.json
+++ b/schema/ngx-schema-form-schema.json
@@ -14,7 +14,7 @@
   ],
   "definitions": {
     "widgetTypeCustom": {
-      "type": "string",
+      "$ref": "#/definition/stringNotBlank",
       "description": "[NSF] - The name of custom widget type to use"
     },
     "widgetTypeSimple": {
@@ -275,6 +275,11 @@
       "type": "object",
       "description": "[NSF] - A form widget.",
       "additionalProperties": true
+    },
+    "stringNotBlank": {
+      "type": "string",
+      "pattern": "^\\S*$",
+      "minLength": 1
     }
   }
 }

--- a/schema/ngx-schema-form-schema.json
+++ b/schema/ngx-schema-form-schema.json
@@ -52,7 +52,7 @@
       "properties": {
         "id": {
           "description": "[NSF] - The id of the widget.",
-          "oneOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/widgetTypeSimple"
             },
@@ -221,7 +221,7 @@
           "description": "[NSF] - The form title of the root form. Will only be showed when is an inline form"
         },
         "widget": {
-          "oneOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/widgetTypeSimple"
             },


### PR DESCRIPTION
- To validate against multiple sub-schemas,  they need to be defined in `allOf`.
- Given that `#/definitions/widgetTypeCustom` accepts any given string `#/definitions/widgetType` must use `anyOf` instead of `oneOf`
![image](https://user-images.githubusercontent.com/600295/102229068-a4ea7e80-3eeb-11eb-899f-b1bae998a1fc.png)
- Allow the use of numbers in `visibleIf`
