### PR TITLE
Add support of nullable union type for oneOf case

### DIFF
--- a/projects/schema-form/src/lib/model/ISchema.ts
+++ b/projects/schema-form/src/lib/model/ISchema.ts
@@ -1,4 +1,4 @@
-import {FieldType} from '../template-schema/field/field';
+import { FieldType, TNullableFieldType } from '../template-schema/field/field';
 
 export interface IOneOf {
   enum?: any[];
@@ -37,9 +37,11 @@ export interface IProperties {
   [prop: string]: ISchema;
 }
 
+export type TSchemaPropertyType = FieldType | TNullableFieldType | 'string' | 'object' | 'array' | 'boolean' | 'integer' | 'number';
+
 export interface ISchema {
   $schema?: string;
-  type?: FieldType | 'string' | 'object' | 'array' | 'boolean' | 'integer' | 'number';
+  type?: TSchemaPropertyType;
   title?: string;
   name?: string;
   description?: string;

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -5,7 +5,7 @@ import {SchemaValidatorFactory} from '../schemavalidatorfactory';
 import {ValidatorRegistry} from './validatorregistry';
 import {PropertyBindingRegistry} from '../property-binding-registry';
 import { ExpressionCompilerFactory, ExpressionCompilerVisibilityIf } from '../expression-compiler-factory';
-import {ISchema} from './ISchema';
+import { ISchema, TSchemaPropertyType } from './ISchema';
 import { LogService } from '../log.service';
 
 export abstract class FormProperty {
@@ -84,7 +84,7 @@ export abstract class FormProperty {
     if (this.schema && this.schema['name']) {
       return this._rootName = this.schema['name'].replace(new RegExp('[\\s]+', 'ig'), '_')
     }
-    return ''
+    return '';
   }
 
   public get valueChanges() {
@@ -95,7 +95,7 @@ export abstract class FormProperty {
     return this._errorsChanges;
   }
 
-  public get type(): string {
+  public get type(): TSchemaPropertyType {
     return this.schema.type;
   }
 

--- a/projects/schema-form/src/lib/model/formpropertyfactory.ts
+++ b/projects/schema-form/src/lib/model/formpropertyfactory.ts
@@ -1,11 +1,12 @@
-import {FormProperty, PropertyGroup} from './formproperty';
-import {SchemaValidatorFactory} from '../schemavalidatorfactory';
-import {ValidatorRegistry} from './validatorregistry';
-import {PropertyBindingRegistry} from '../property-binding-registry';
+import { FormProperty, PropertyGroup } from './formproperty';
+import { SchemaValidatorFactory } from '../schemavalidatorfactory';
+import { ValidatorRegistry } from './validatorregistry';
+import { PropertyBindingRegistry } from '../property-binding-registry';
 import { ExpressionCompilerFactory } from '../expression-compiler-factory';
 import { PROPERTY_TYPE_MAPPING } from './typemapping';
-import {ISchema} from './ISchema';
+import { ISchema, TSchemaPropertyType } from './ISchema';
 import { LogService } from '../log.service';
+import { TNullableFieldType, FieldType } from '../template-schema/field/field';
 
 export class FormPropertyFactory {
 
@@ -44,17 +45,23 @@ export class FormPropertyFactory {
       const refSchema = this.schemaValidatorFactory.getSchema(parent.root.schema, schema.$ref);
       newProperty = this.createProperty(refSchema, parent, path);
     } else {
-        if (PROPERTY_TYPE_MAPPING[schema.type]) {
-            if (schema.type === 'object' || schema.type === 'array') {
-                newProperty = PROPERTY_TYPE_MAPPING[schema.type](
-                    this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path, this, this.logger);
-            } else {
-                newProperty = PROPERTY_TYPE_MAPPING[schema.type](
-                    this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path, this.logger);
-            }
+      const type: FieldType = this.isUnionType(schema.type)
+        && this.isValidNullableUnionType(schema.type as TNullableFieldType)
+        && this.isAllowedToUsingNullableUnionTypeBySchemaContext(schema)
+          ? this.extractTypeFromNullableUnionType(schema.type as TNullableFieldType)
+          :  schema.type as FieldType;
+
+      if (PROPERTY_TYPE_MAPPING[type]) {
+        if (type === 'object' || type === 'array') {
+          newProperty = PROPERTY_TYPE_MAPPING[type](
+          this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path, this, this.logger);
         } else {
-            throw new TypeError(`Undefined type ${schema.type} (existing: ${Object.keys(PROPERTY_TYPE_MAPPING)})`);
+          newProperty = PROPERTY_TYPE_MAPPING[type](
+          this.schemaValidatorFactory, this.validatorRegistry, this.expressionCompilerFactory, schema, parent, path, this.logger);
         }
+      } else {
+        throw new TypeError(`Undefined type ${type} (existing: ${Object.keys(PROPERTY_TYPE_MAPPING)})`);
+      }
     }
 
     newProperty._propertyBindingRegistry = this.propertyBindingRegistry;
@@ -70,5 +77,39 @@ export class FormPropertyFactory {
   private initializeRoot(rootProperty: PropertyGroup) {
     rootProperty.reset(null, true);
     rootProperty._bindVisibility();
+  }
+
+  private isUnionType(unionType: TSchemaPropertyType): boolean {
+    return Array.isArray(unionType) && unionType.length > 1;
+  }
+
+  private isValidNullableUnionType(unionType: TNullableFieldType): boolean {
+    if (!unionType.some(subType => subType === 'null')) {
+      throw new TypeError(`Unsupported union type ${unionType}. Supports only nullable union types, for example ["string", "null"]`);
+    }
+
+    if (unionType.length !== 2) {
+      throw new TypeError(`Unsupported count of types in nullable union type ${unionType}. Supports only two types one of the which should be "null"`);
+    }
+
+    const type = this.extractTypeFromNullableUnionType(unionType);
+
+    if (!type || [FieldType.Object, FieldType.Array].includes(type)) {
+      throw new TypeError(`Unsupported second type ${type} for nullable union. Allowed types are "${FieldType.Number}", "${FieldType.Integer}", "${FieldType.Boolean}", "${FieldType.String}"`);
+    }
+
+    return true;
+  }
+
+  private extractTypeFromNullableUnionType(unionType: TNullableFieldType): FieldType | undefined {
+    return unionType.filter(type => type !== 'null')?.[0] as FieldType | undefined;
+  }
+
+  private isAllowedToUsingNullableUnionTypeBySchemaContext(schema: ISchema): boolean {
+    if (!schema.oneOf) {
+      throw new TypeError(`Unsupported using of nullable union type without "oneOf" attribute`);
+    }
+
+    return true;
   }
 }

--- a/projects/schema-form/src/lib/model/typemapping.ts
+++ b/projects/schema-form/src/lib/model/typemapping.ts
@@ -1,1 +1,5 @@
-export const PROPERTY_TYPE_MAPPING: { [type: string]: any } = {};
+import { FieldType } from '../template-schema/field/field';
+
+export type TPropertyTypeMapping = { [type in FieldType]?: any };
+
+export const PROPERTY_TYPE_MAPPING: TPropertyTypeMapping  = {};

--- a/projects/schema-form/src/lib/template-schema/field/field.ts
+++ b/projects/schema-form/src/lib/template-schema/field/field.ts
@@ -10,6 +10,9 @@ export enum FieldType {
   Number = 'number',
 }
 
+export type TNullableFieldType = [FieldType.String | FieldType.Number | FieldType.Boolean | FieldType.Integer, 'null']
+  | ['null', FieldType.String | FieldType.Number | FieldType.Boolean | FieldType.Integer];
+
 export interface Field {
   name: string;
   required: boolean;


### PR DESCRIPTION
Solution based on proposal which is told in #397 with one exception, I limited possible use cases to one: currently allowed to use union type only with oneOf.
Another cases might ruin the widgets or might happen something an unpredictable at validation process or casting value or something else.
Allowed types to mixing in with null are "integer", "number", "string", "boolean".