### PR TITLE
Use DisableControlDirective for widgets to remove warnings for reactive forms.

### DIFF
--- a/projects/schema-form/src/lib/defaultwidgets/checkbox/checkbox.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/checkbox/checkbox.widget.ts
@@ -10,7 +10,7 @@ import { ControlWidget } from '../../widget';
     </label>
 	<div *ngIf="schema.type!='array'" class="checkbox">
 		<label class="horizontal control-label">
-			<input [formControl]="control" [attr.name]="name" [attr.id]="id" [indeterminate]="control.value !== false && control.value !== true ? true :null" type="checkbox" [disabled]="schema.readOnly">
+			<input [formControl]="control" [attr.name]="name" [attr.id]="id" [indeterminate]="control.value !== false && control.value !== true ? true :null" type="checkbox" [disableControl]="schema.readOnly">
 			<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
 			{{schema.description}}
 		</label>

--- a/projects/schema-form/src/lib/defaultwidgets/radio/radio.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/radio/radio.widget.ts
@@ -9,7 +9,7 @@ import { ControlWidget } from '../../widget';
   <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
 	<div *ngFor="let option of schema.oneOf" class="radio">
 		<label class="horizontal control-label">
-			<input [formControl]="control" [attr.name]="name" [attr.id]="id + '.' + option.enum[0]" value="{{option.enum[0]}}" type="radio"  [disabled]="schema.readOnly||option.readOnly">
+			<input [formControl]="control" [attr.name]="name" [attr.id]="id + '.' + option.enum[0]" value="{{option.enum[0]}}" type="radio"  [disableControl]="schema.readOnly||option.readOnly">
 			{{option.description}}
 		</label>
 	</div>

--- a/projects/schema-form/src/lib/defaultwidgets/range/range.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/range/range.widget.ts
@@ -10,7 +10,7 @@ import { ControlWidget } from '../../widget';
 	</label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>	
 	<input [name]="name" class="text-widget range-widget" [attr.id]="id"
-	[formControl]="control" [attr.type]="'range'" [attr.min]="schema.minimum" [attr.max]="schema.maximum" [disabled]="schema.readOnly?true:null" >
+	[formControl]="control" [attr.type]="'range'" [attr.min]="schema.minimum" [attr.max]="schema.maximum" [disableControl]="schema.readOnly?true:null" >
 	<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden">
 </div>`
 })

--- a/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/select/select.widget.ts
@@ -13,7 +13,7 @@ import { ControlWidget } from '../../widget';
 		{{schema.description}}
 	</span>
 
-	<select *ngIf="schema.type!='array'" [formControl]="control" [attr.name]="name" [attr.id]="id" [disabled]="schema.readOnly" [disableControl]="schema.readOnly" class="form-control">
+	<select *ngIf="schema.type!='array'" [formControl]="control" [attr.name]="name" [attr.id]="id" [disableControl]="schema.readOnly" class="form-control">
 		<ng-container *ngIf="schema.oneOf; else use_enum">
 			<option *ngFor="let option of schema.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
 		</ng-container>
@@ -22,7 +22,7 @@ import { ControlWidget } from '../../widget';
 		</ng-template>
 	</select>
 
-	<select *ngIf="schema.type==='array'" multiple [formControl]="control" [attr.name]="name" [attr.id]="id" [disabled]="schema.readOnly" [disableControl]="schema.readOnly" class="form-control">
+	<select *ngIf="schema.type==='array'" multiple [formControl]="control" [attr.name]="name" [attr.id]="id" [disableControl]="schema.readOnly" class="form-control">
     <option *ngFor="let option of schema.items.oneOf" [ngValue]="option.enum[0]" [disabled]="option.readOnly">{{option.description}}</option>
 	</select>
 

--- a/projects/schema-form/src/lib/defaultwidgets/string/string.widget.ts
+++ b/projects/schema-form/src/lib/defaultwidgets/string/string.widget.ts
@@ -19,7 +19,7 @@ import { ControlWidget } from '../../widget';
     [attr.maxLength]="schema.maxLength || null"
     [attr.minLength]="schema.minLength || null"
     [attr.required]="schema.isRequired || null"
-    [attr.disabled]="(schema.widget.id=='color' && schema.readOnly)?true:null">
+	[disableControl]="(schema.widget.id=='color' && schema.readOnly)?true:null">
     <input *ngIf="(schema.widget.id==='color' && schema.readOnly)" [attr.name]="name" type="hidden" [formControl]="control">
 </div>
 </ng-template>`


### PR DESCRIPTION
In dev mode there is the famous warning about reactive forms and disable attribute
```
  It looks like you're using the disabled attribute with a reactive form directive. If you set disabled to true
  when you set up this control in your component class, the disabled attribute will actually be set in the DOM for
  you. We recommend using this approach to avoid 'changed after checked' errors.

  Example:
  form = new FormGroup({
    first: new FormControl({value: 'Nancy', disabled: true}, Validators.required),
    last: new FormControl('Drew', Validators.required)
  });
```

I changed the widgets to use the already existing `DisableControlDirective`. The select widget had both methods: Attribute and via directive therefore I removed the attribute method.