### PR TITLE
Fix for  #431

### DIFF
--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -249,7 +249,7 @@ export abstract class FormProperty {
         if (typeof expString === 'boolean') {
           valid = !expString ? !value : value
         } else if (typeof expString === 'number') {
-          valid = !!value ? `${expString}` === `${value}` : false;
+          valid = (!!value || value == 0) ? `${expString}` === `${value}` : false;
         } else if (-1 !== `${expString}`.indexOf('$ANY$')) {
           if(Array.isArray(value)) {
             valid = value.length > 0;


### PR DESCRIPTION
This is a fix for the issue #431 .

Because `value` can be the number `0` it will not correctly evaluate the expression and always returns false for the `visibleIf` because `!!value` for `0` is always false.

With this patch the `value` needs to be defined by checking `!!value` or it needs to be the number `0`.