### PR TITLE
feat: Added chainable oneOf and allOf in visibleIf

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,20 @@ Where `oneOf` is handled as `OR` and `allOf` is handled as `AND`.
 The `oneOf` a is prioritized before the `allOf` and both are prioritized before the
 property binding.
 
+Chaining of `oneOf` and `allOf` is possible like in the exmaple below:
+```
+"visibleIf": {
+  "allOf": [
+    {
+      "oneOf": [{ "/demo/visibleIfBinding1/status1a": ["Pass"] }, { "/demo/visibleIfBinding1/status1b": ["Pass"] }]
+    },
+    {
+      "oneOf": [{ "/demo/visibleIfBinding1/status1c": ["Pass"] }, { "/demo/visibleIfBinding1/status1d": ["Pass"] }]
+    }
+  ]
+}
+```
+
 _`oneOf` and `allOf` oneOf and allOf are reserved keywords and not suitable as property names_
 
 **Arrays**

--- a/src/app/json-schema-example/json-schema-example.component.canonical-path.spec.ts
+++ b/src/app/json-schema-example/json-schema-example.component.canonical-path.spec.ts
@@ -92,7 +92,7 @@ describe('JsonSchemaExampleComponent - canonical-path', () => {
 
     // select demo sample
     const select: HTMLSelectElement = fixture.debugElement.query(By.css('#samples')).nativeElement;
-    select.value = select.options[5].value;  // <-- select a new value
+    select.value = select.options[6].value;  // <-- select a new value
     select.dispatchEvent(new Event('change'));
     fixture.detectChanges();
   });

--- a/src/app/json-schema-example/json-schema-example.component.ts
+++ b/src/app/json-schema-example/json-schema-example.component.ts
@@ -14,6 +14,7 @@ import binding_sample_model from './binding_sample_model.json';
 import binding_sample_bindings from './binding_sample_bindings';
 import visibility_binding_example from './visibility-binding-example-schema.json';
 import visibility_binding_example2 from './visibility-binding-example-schema2.json';
+import visibility_binding_example3 from './visibility-binding-example-schema3.json';
 import sample_canonical_path from './sample-canonical-path.json';
 
 import {AppService, AppData} from '../app.service';
@@ -41,7 +42,8 @@ export class JsonSchemaExampleComponent implements OnInit, OnDestroy {
     {label: 'Sample 3 - Otherschema', event: this.changeSchemaOtherschema, selected: false},
     {label: 'Sample 4 - Visibility binding', event: this.changeSchemaVisibilityBinding, selected: false},
     {label: 'Sample 5 - Visibility binding 2', event: this.changeSchemaVisibilityBinding2, selected: false},
-    {label: 'Sample 6 - Canonical path', event: this.changeSchemaCanonicalPath, selected: false},
+    {label: 'Sample 6 - Visibility binding 3', event: this.changeSchemaVisibilityBinding3, selected: false},
+    {label: 'Sample 7 - Canonical path', event: this.changeSchemaCanonicalPath, selected: false},
   ];
 
   constructor(
@@ -213,6 +215,14 @@ export class JsonSchemaExampleComponent implements OnInit, OnDestroy {
 
   changeSchemaVisibilityBinding2() {
     this.schema = visibility_binding_example2 as unknown as ISchema;
+    this.model = {};
+    this.fieldBindings = {};
+    this.fieldValidators = {};
+    this.actions = {};
+  }
+
+  changeSchemaVisibilityBinding3() {
+    this.schema = visibility_binding_example3 as unknown as ISchema;
     this.model = {};
     this.fieldBindings = {};
     this.fieldValidators = {};

--- a/src/app/json-schema-example/json-schema-example.component.visibleIf.spec.ts
+++ b/src/app/json-schema-example/json-schema-example.component.visibleIf.spec.ts
@@ -689,3 +689,131 @@ describe('JsonSchemaExampleComponent - visibleIf - condition-types', () => {
 
 });
 
+describe("JsonSchemaExampleComponent - visibleIf - condition-types (chained conditions)", () => {
+  let component: JsonSchemaExampleComponent;
+  let fixture: ComponentFixture<JsonSchemaExampleComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [SchemaFormModule.forRoot(), HttpClientModule, FormsModule, ReactiveFormsModule],
+      declarations: [JsonSchemaExampleComponent],
+      providers: [
+        { provide: WidgetRegistry, useClass: DefaultWidgetRegistry },
+        {
+          provide: SchemaValidatorFactory,
+          useClass: ZSchemaValidatorFactory
+        }
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(JsonSchemaExampleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  beforeEach(() => {
+    // select demo sample
+    const select: HTMLSelectElement = fixture.debugElement.query(By.css("#samples")).nativeElement;
+    select.value = select.options[5].value; // <-- select a new value
+    select.dispatchEvent(new Event("change"));
+    fixture.detectChanges();
+  });
+
+  it(`# 1. Test 'VisibleIf' with 'all-of' of 'one-of's. One of 1a and 1b must be Pass and one of 1c and 1d must be Pass`, async(() => {
+    // Visible component shows up if status value is 'Warn' or 'Fail'
+
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      // expect page containing a sf-form element
+      let sf_form = fixture.debugElement.query(By.css("sf-form"));
+      expect(sf_form).toBeTruthy();
+
+      // initial state
+      let _test_status1a = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding1\\.status1a")).nativeElement;
+      expect(_test_status1a.value).toBe("");
+      let _test_status1b = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding1\\.status1b")).nativeElement;
+      expect(_test_status1b.value).toBe("");
+      let _test_status1c = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding1\\.status1c")).nativeElement;
+      expect(_test_status1c.value).toBe("");
+      let _test_status1d = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding1\\.status1d")).nativeElement;
+      expect(_test_status1d.value).toBe("");
+
+      let _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding1\\.visibleComponent1a"));
+      expect(_test_visbility).toBeNull();
+
+      // change some values which still not met the condition
+      _test_status1a.value = _test_status1a.options[0].value;
+      _test_status1b.value = _test_status1b.options[0].value;
+      _test_status1a.dispatchEvent(new Event("change"));
+      _test_status1b.dispatchEvent(new Event("change"));
+      fixture.detectChanges();
+      _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding1\\.visibleComponent1a"));
+      expect(_test_visbility).toBeNull();
+
+      // change state to make field visible
+      _test_status1c.value = _test_status1c.options[0].value;
+      _test_status1c.dispatchEvent(new Event("change"));
+      fixture.detectChanges();
+      _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding1\\.visibleComponent1a"));
+      expect(_test_visbility).toBeTruthy();
+    });
+  }));
+
+  it(`# 2. Test 'VisibleIf' with 'one-of' of 'all-of's. All of 2a, 2b and 2c must be Fail or 2d must be Fail`, async(() => {
+    // Visible component shows up if status value is 'Warn' or 'Fail'
+
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      // expect page containing a sf-form element
+      let sf_form = fixture.debugElement.query(By.css("sf-form"));
+      expect(sf_form).toBeTruthy();
+
+      // initial state
+      let _test_status2a = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.status2a")).nativeElement;
+      expect(_test_status2a.value).toBe("");
+      let _test_status2b = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.status2b")).nativeElement;
+      expect(_test_status2b.value).toBe("");
+      let _test_status2c = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.status2c")).nativeElement;
+      expect(_test_status2c.value).toBe("");
+      let _test_status2d = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.status2d")).nativeElement;
+      expect(_test_status2d.value).toBe("");
+
+      let _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.visibleComponent2a"));
+      expect(_test_visbility).toBeNull();
+
+      // change some values which still not met the condition
+      _test_status2a.value = _test_status2a.options[2].value;
+      _test_status2b.value = _test_status2b.options[2].value;
+      _test_status2a.dispatchEvent(new Event("change"));
+      _test_status2b.dispatchEvent(new Event("change"));
+      fixture.detectChanges();
+      _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.visibleComponent2a"));
+      expect(_test_visbility).toBeNull();
+
+      // change state to make field visible
+      _test_status2c.value = _test_status2c.options[2].value;
+      _test_status2c.dispatchEvent(new Event("change"));
+      fixture.detectChanges();
+      _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.visibleComponent2a"));
+      expect(_test_visbility).toBeTruthy();
+
+      // change state to make field invisible
+      _test_status2c.value = _test_status2c.options[0].value;
+      _test_status2c.dispatchEvent(new Event("change"));
+      fixture.detectChanges();
+      _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.visibleComponent2a"));
+      expect(_test_visbility).toBeNull();
+
+      // change state to make field visible
+      _test_status2d.value = _test_status2c.options[2].value;
+      _test_status2d.dispatchEvent(new Event("change"));
+      fixture.detectChanges();
+      _test_visbility = fixture.debugElement.query(By.css("#demo\\.visibleIfBinding2\\.visibleComponent2a"));
+      expect(_test_visbility).toBeTruthy();
+    });
+  }));
+});

--- a/src/app/json-schema-example/visibility-binding-example-schema3.json
+++ b/src/app/json-schema-example/visibility-binding-example-schema3.json
@@ -1,0 +1,205 @@
+{
+  "properties": {
+    "demo": {
+      "type": "object",
+      "properties": {
+        "visibleIfBinding1": {
+          "description": "# 1. Test 'VisibleIf' with 'all-of' of 'one-of's. One of 1a and 1b must be Pass and one of 1c and 1d must be Pass",
+          "type": "object",
+          "properties": {
+            "status1a": {
+              "type": "string",
+              "description": "Status 1a",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "status1b": {
+              "type": "string",
+              "description": "Status 1b",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "status1c": {
+              "type": "string",
+              "description": "Status 1c",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "status1d": {
+              "type": "string",
+              "description": "Status 1d",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "visibleComponent1a": {
+              "type": "string",
+              "description": "Visible component if above condition is fulfilled",
+              "visibleIf": {
+                "allOf": [
+                  {
+                    "oneOf": [{ "/demo/visibleIfBinding1/status1a": ["Pass"] }, { "/demo/visibleIfBinding1/status1b": ["Pass"] }]
+                  },
+                  {
+                    "oneOf": [{ "/demo/visibleIfBinding1/status1c": ["Pass"] }, { "/demo/visibleIfBinding1/status1d": ["Pass"] }]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "visibleIfBinding2": {
+          "description": "# 2. Test 'VisibleIf' with 'one-of' of 'all-of's. All of 2a, 2b and 2c must be Fail or 2d must be Fail",
+          "type": "object",
+          "properties": {
+            "status2a": {
+              "type": "string",
+              "description": "Status 2a",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "status2b": {
+              "type": "string",
+              "description": "Status 2b",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "status2c": {
+              "type": "string",
+              "description": "Status 2c",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "status2d": {
+              "type": "string",
+              "description": "Status 2d",
+              "oneOf": [
+                {
+                  "description": "Pass",
+                  "enum": ["Pass"]
+                },
+                {
+                  "description": "Warn",
+                  "enum": ["Warn"]
+                },
+                {
+                  "description": "Fail",
+                  "enum": ["Fail"]
+                }
+              ],
+              "widget": "select"
+            },
+            "visibleComponent2a": {
+              "type": "string",
+              "description": "Visible component if above condition is fulfilled",
+              "visibleIf": {
+                "oneOf": [
+                  {
+                    "allOf": [
+                      { "/demo/visibleIfBinding2/status2a": ["Fail"] },
+                      { "/demo/visibleIfBinding2/status2b": ["Fail"] },
+                      { "/demo/visibleIfBinding2/status2c": ["Fail"] }
+                    ]
+                  },
+                  {
+                    "allOf": [{ "/demo/visibleIfBinding2/status2d": ["Fail"] }]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added a chainable oneOf and allOf for the visibleIf property. Now, arbitrary boolean expressions can be written down. 2 tests were added and documentation is also modified.

All tests were successfully locally. So, I think that this is not a breaking change even I had to rewrite / rearrange a big part of `__bindVisibility_oneOf_or_allOf` method. I'm very unsure if the schema itself needs a modification.

For the record: I have a rather complex form, where just "or" or just "and" everything is not sufficient. I need expression like (a && b) || (a && c) etc. in the visibleIf. Therefore I implemented this patch.