### PR TITLE
Not working two-way data binding in corner cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ Where `oneOf` is handled as `OR` and `allOf` is handled as `AND`.
 The `oneOf` a is prioritized before the `allOf` and both are prioritized before the
 property binding.
 
-Chaining of `oneOf` and `allOf` is possible like in the exmaple below:
+Chaining of `oneOf` and `allOf` is possible like in the example below:
 ```
 "visibleIf": {
   "allOf": [
@@ -649,7 +649,7 @@ Chaining of `oneOf` and `allOf` is possible like in the exmaple below:
 }
 ```
 
-_`oneOf` and `allOf` oneOf and allOf are reserved keywords and not suitable as property names_
+_`oneOf` and `allOf` are reserved keywords and not suitable as property names_
 
 **Arrays**
 

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -319,7 +319,7 @@ export abstract class FormProperty {
     if (visibleIfProperty && oneOfOrAllOf) {
       const finalObservable: Observable<boolean> = this.__bindConditionalVisiblityChain(oneOfOrAllOf, !!visibleIfProperty.oneOf, !!visibleIfProperty.allOf);
       // subscribe to the last observable which collects all temporary results
-      finalObservable.subscribe(visible => {
+      finalObservable.pipe(distinctUntilChanged()).subscribe((visible) => {
         this.setVisible(visible);
       });
       return true;


### PR DESCRIPTION
Once again a pull request by me.
I have no idea why this patch is working and I really like to discuss that because I don't like to blindly provide patches where I don't know why they are working.

### How to reproduce?
In this reprox https://stackblitz.com/edit/angular-ivy-cxvsbz?file=src/app/app.component.ts click `Press to change` and see that the child object in `Non working` is not changed to `Desc. of child element 2` but in the second form in `Working` it is changed to `Desc. of child element 2`.

### What's the difference?
The non working schema uses `allOf` in `visibleIf` while the second just uses `visibleIf` **without** `allOf` or `oneOf`

### What's the patch doing?
It simply a one liner where I change from `subscribe` to `pipe` with `disctinctUntilChanged` within the binding function for `allOf` and `oneOf`. That's the same way as it is done when providing nothing for `visibleIf` (that's how I get to this solution).

### Is this a regression?
No. Even I nearly complete have rewritten the `oneOf` and `allOf` binding myself in my last pull request, you can use version `2.8.1` and `2.8.2` in my reprox withouth any change. In `2.8.1` the subscription was done the same way as in the newer `2.8.2` version with my rewrite: https://github.com/guillotinaweb/ngx-schema-form/blob/410b38dda91428dc44ecd3b1c8d60ad1ce829f1e/projects/schema-form/src/lib/model/formproperty.ts#L372-L379

### What's happening?
So, I have really no idea why it works with my patch. What I think I understand so far, is that somehow the different subscription overwrites the data in the model when changed. But why and how does this work?
See the output where the non working schema output before a change, then after change and then after a timeout of 1 second where it is back in the state before.
![grafik](https://user-images.githubusercontent.com/38033805/186405495-10840ad2-e641-4e49-96b3-69f5a04d949d.png)
