### PR TITLE
Regression fix and further performance boost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.8.5 (2022-10-13)
+
+- Fixed bug with wildcards introduced by version 2.8.2 (Kevin Broichhausen)
+- Bind visiblity checks after properties are created for better performance (Kevin Broichhausen)
+
 # 2.8.4 (2022-09-09)
 
 - Improved performance of visibility binding for nested objects (Kevin Broichhausen)

--- a/projects/schema-form/src/lib/form.component.ts
+++ b/projects/schema-form/src/lib/form.component.ts
@@ -155,6 +155,7 @@ export class FormComponent implements OnChanges, ControlValueAccessor {
 
     if (this.schema && (changes.model || changes.schema )) {
       this.rootProperty.reset(this.model, false);
+      this.rootProperty._bindVisibility();
       this.cdr.detectChanges();
     }
 

--- a/projects/schema-form/src/lib/model/formproperty.ts
+++ b/projects/schema-form/src/lib/model/formproperty.ts
@@ -364,8 +364,8 @@ export abstract class FormProperty {
         return this.__bindConditionalVisiblityChain(visibleIfOf, containsOneOf, containsAllOf);
       } else {
         // it's a dependency path
-        const obsersables = this.__handleDependencyPath(visbilityElement);
-		return combineLatest(obsersables, (...values: boolean[]) => values.indexOf(true) !== -1);
+        const observables = this.__handleDependencyPath(visbilityElement);
+        return combineLatest(observables, (...values: boolean[]) => values.indexOf(true) !== -1);
       }
     }
 
@@ -385,7 +385,7 @@ export abstract class FormProperty {
     const dependencyPath = Object.keys(dependencyElement)[0];
 
     const propertiesBinding = [];
-	const properties = this.findProperties(this, dependencyPath);
+    const properties = this.findProperties(this, dependencyPath);
     if ((properties || []).length) {
       for (const property of properties) {
         if (property) {
@@ -395,7 +395,7 @@ export abstract class FormProperty {
           valueCheck = property.valueChanges.pipe(map(_chk));
           const visibilityCheck = property._visibilityChanges;
           const and = combineLatest([valueCheck, visibilityCheck], (v1, v2) => v1 && v2);
-		  propertiesBinding.push(and);
+          propertiesBinding.push(and);
         }
       }
 	  return propertiesBinding;

--- a/projects/schema-form/src/lib/model/formpropertyfactory.ts
+++ b/projects/schema-form/src/lib/model/formpropertyfactory.ts
@@ -65,6 +65,8 @@ export class FormPropertyFactory {
     newProperty._propertyBindingRegistry = this.propertyBindingRegistry;
     newProperty._canonicalPath = _canonicalPath;
 
+    if (newProperty instanceof PropertyGroup) newProperty.reset(null, true);
+
     return newProperty;
   }
 

--- a/projects/schema-form/src/lib/model/formpropertyfactory.ts
+++ b/projects/schema-form/src/lib/model/formpropertyfactory.ts
@@ -65,17 +65,9 @@ export class FormPropertyFactory {
     newProperty._propertyBindingRegistry = this.propertyBindingRegistry;
     newProperty._canonicalPath = _canonicalPath;
 
-    if (newProperty instanceof PropertyGroup) {
-      this.initializeRoot(newProperty);
-    }
-
     return newProperty;
   }
 
-  private initializeRoot(rootProperty: PropertyGroup) {
-    rootProperty.reset(null, true);
-    rootProperty._bindVisibility();
-  }
 
   private isUnionType(unionType: TSchemaPropertyType): boolean {
     return Array.isArray(unionType) && unionType.length > 1;


### PR DESCRIPTION
First patch fixes an issue with wildcards. I added chainable allOf and oneOf in a previous patch but misunderstood the `findProperties` and immediately returned after first one was processed. So, the second, third etc. elements were not used.

Second patch is for performance. I think, I eliminated all unneccessary multiple calls to bindVisiblity method.
When root element is created, it already creates all child elements / properties but now no call to bindVisiblity is made. Just after the root element's creation is done, bindVisibility is called, which also processes all childs. So far this works fine for me because the `ExtendedProxyHandler` already takes care of rebinding on changes (like adding an element to an array).
I hope there are no other use cases which will fail with this patch.