### PR TITLE
Remove invisible elements from model at root level

### DIFF
--- a/projects/schema-form/src/lib/form.component.ts
+++ b/projects/schema-form/src/lib/form.component.ts
@@ -199,6 +199,7 @@ export class FormComponent implements OnChanges, ControlValueAccessor {
 
   private setModel(value: any) {
     if (this.model) {
+      for (const key of Object.keys(this.model)) delete this.model[key];
       Object.assign(this.model, value);
     } else {
       this.model = value;


### PR DESCRIPTION
Due to `Object.assign` elements on root level like
this.model = 
```
{
   "old": "foo"
}
```

and value =
```
{
   "new": "bar"
}
```
gets merged to
```
{
   "old": "foo",
   "new": "bar"
}
```
but `old` is not visible anymore and should be removed from the model.

Assignment like `this.model = value` is also bad because this leads to bad behaviour with two-way data binding. I tried to use assignment with a change event to tell the parent that the child (`FormComponent`) has changed the model but because `FormComponent` implements `OnChanges` I had a loop.

Not the best fix but at least it just iterates through the keys at root level of the model and **not** into the nested structure.