### PR TITLE
Bind visibility after creation to prevent multiple calls

### DIFF
--- a/projects/schema-form/src/lib/form.component.ts
+++ b/projects/schema-form/src/lib/form.component.ts
@@ -155,6 +155,7 @@ export class FormComponent implements OnChanges, ControlValueAccessor {
 
     if (this.schema && (changes.model || changes.schema )) {
       this.rootProperty.reset(this.model, false);
+      this.rootProperty._bindVisibility();
       this.cdr.detectChanges();
     }
 

--- a/projects/schema-form/src/lib/model/formpropertyfactory.ts
+++ b/projects/schema-form/src/lib/model/formpropertyfactory.ts
@@ -65,16 +65,9 @@ export class FormPropertyFactory {
     newProperty._propertyBindingRegistry = this.propertyBindingRegistry;
     newProperty._canonicalPath = _canonicalPath;
 
-    if (newProperty instanceof PropertyGroup) {
-      this.initializeRoot(newProperty);
-    }
+    if (newProperty instanceof PropertyGroup) newProperty.reset(null, true);
 
     return newProperty;
-  }
-
-  private initializeRoot(rootProperty: PropertyGroup) {
-    rootProperty.reset(null, true);
-    rootProperty._bindVisibility();
   }
 
   private isUnionType(unionType: TSchemaPropertyType): boolean {


### PR DESCRIPTION
First create the elements and then create initial bind of visibility by calling `_bindVisibility` just for the root element.

If you have many nested objects, this is a lot faster because each `PropertyGroup` does not call `_bindVisibility` at creation. Previously, it was called for each one at creation but eventually it will get called anyways because root element is a `PropertyGroup` which calls `_bindVisibility` of childs (and therefore for child `PropertyGroup`s).