### PR TITLE
🏷️ Add type for mySchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Let's start by creating a simple AppComponent taking a simple JSON schema as inp
 // app.component.ts
 
 import { Component } from "@angular/core";
+import { ISchema } from 'ngx-schema-form';
 
 @Component({
   selector: "minimal-app",
@@ -67,7 +68,7 @@ import { Component } from "@angular/core";
 })
 export class AppComponent {
   // The schema that will be used to generate a form
-  mySchema = {
+  mySchema: ISchema = {
     properties: {
       email: {
         type: "string",


### PR DESCRIPTION
Facing this issue when following the [getting started](https://github.com/guillotinaweb/ngx-schema-form#getting-started) and saw others are facing it as well #459 

I was able to build the app demo and noticed the [schema type is declared there](https://github.com/guillotinaweb/ngx-schema-form/blob/7e35e19e5e282b248c6fbeee6ab8c24f249dc623/src/app/json-schema-example/json-schema-example.component.ts#L29), so thinking this could be an omission?

---

Thanks for your work on this library! It is saving our team lots of time 🍻